### PR TITLE
Add varshort data type

### DIFF
--- a/doc/datatypes.md
+++ b/doc/datatypes.md
@@ -163,6 +163,14 @@ Size: between 1 and 5
 
 Example of value : `5`
 
+### varshort
+
+A variable-length extended unsigned short, ranging from 0 to 0x7fffff
+
+Size: 2 (up to 0x7fff, similar to `short`) or 3 bytes
+
+Example of value : `255047`
+
 ### bool
 
 A boolean, encoded in one byte.

--- a/test/dataTypes/utils.js
+++ b/test/dataTypes/utils.js
@@ -38,6 +38,95 @@ describe('Utils', function() {
     it.skip('Has no tests', function() {
     });
   });
+
+  describe('.varshort', function() {
+   it('Reads short integer', function() {
+     var buf = new Buffer([0x01, 0x02]);
+     expect(getReader(utils.varshort)(buf, 0, [], {})).to.deep.equal({
+       value: 0x0102,
+       size: 2
+     });
+   });
+   it('Reads short integer maximum', function() {
+     var buf = new Buffer([0x7f, 0xff]);
+     expect(getReader(utils.varshort)(buf, 0, [], {})).to.deep.equal({
+       value: 0x7fff,
+       size: 2
+     });
+   });
+   it('Reads varshort integer', function() {
+     var buf = new Buffer([0xe4, 0x47, 0x07]);
+     expect(getReader(utils.varshort)(buf, 0, [], {})).to.deep.equal({
+       value: 255047,
+       size: 3
+     });
+   });
+   it('Reads varshort integer minimum', function() {
+     var buf = new Buffer([0x80, 0x00, 0x01]);
+     expect(getReader(utils.varshort)(buf, 0, [], {})).to.deep.equal({
+       value: 0x8000,
+       size: 3
+     });
+   });
+   it('Reads varshort integer maximum', function() {
+     var buf = new Buffer([0xff, 0xff, 0xff]);
+     expect(getReader(utils.varshort)(buf, 0, [], {})).to.deep.equal({
+       value: 0x7fffff,
+       size: 3
+     });
+   });
+
+
+   it('Size of short integer', function() {
+     assert.equal(getSizeOf(utils.varshort)(0x0102), 2);
+   });
+   it('Size of varshort integer', function() {
+     assert.equal(getSizeOf(utils.varshort)(255047), 3);
+   });
+   it('Size of too big', function() {
+    try {
+      getSizeOf(utils.varshort)(0x800000);
+      throw new Error('unexpectedly returned from size of too big');
+    } catch(e) {
+      assert.ok(e.name, 'AssertionError');
+    }
+   });
+   it('Size of too small', function() {
+    try {
+      getSizeOf(utils.varshort)(-1);
+      throw new Error('unexpectedly returned from size of too small');
+    } catch(e) {
+      assert.ok(e.name, 'AssertionError');
+    }
+   });
+
+   it('Writes short integer', function() {
+    var buf = new Buffer(2);
+    assert.equal(getWriter(utils.varshort)(0x0102, buf, 0, [], {}), 2);
+    assert.deepEqual(buf, new Buffer([0x01, 0x02]));
+   });
+   it('Writes short integer maximum', function() {
+    var buf = new Buffer(2);
+    assert.equal(getWriter(utils.varshort)(0x7fff, buf, 0, [], {}), 2);
+    assert.deepEqual(buf, new Buffer([0x7f, 0xff]));
+   });
+   it('Writes varshort integer', function() {
+    var buf = new Buffer(3);
+    assert.equal(getWriter(utils.varshort)(255047, buf, 0, [], {}), 3);
+    assert.deepEqual(buf, new Buffer([0xe4, 0x47, 0x07]));
+   });
+   it('Writes varshort integer minimum', function() {
+    var buf = new Buffer(3);
+    assert.equal(getWriter(utils.varshort)(0x8000, buf, 0, [], {}), 3);
+    assert.deepEqual(buf, new Buffer([0x80, 0x00, 0x01]));
+   });
+   it('Writes varshort integer maximum', function() {
+    var buf = new Buffer(3);
+    assert.equal(getWriter(utils.varshort)(0x7fffff, buf, 0, [], {}), 3);
+    assert.deepEqual(buf, new Buffer([0xff, 0xff, 0xff]));
+   });
+  });
+
   describe('.buffer', function() {
     it.skip('Has no tests', function() {
     });


### PR DESCRIPTION
Extended 'short' type, see http://wiki.vg/Minecraft_Forge_Handshake#Definitions

With this PR and minecraft-data 1.7 plugin_channel 0x3f updated to varshort, able to login to an FTBInfinityServer-2.3.5-1.7.10 server (although it later crashes due to use of other custom packets)

ref https://github.com/PrismarineJS/node-minecraft-protocol-forge/pull/7

Closes https://github.com/PrismarineJS/node-minecraft-protocol-forge/issues/1 (couldn't make the change in nmp-f because it requires changing the protocol definition in minecraft-data unfortunately, but it is backwards-compatible with vanilla 1.7)
