### PR TITLE
add a full packet parser

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ module.exports = {
   ProtoDef:ProtoDef,
   Serializer:require("./serializer").Serializer,
   Parser:require("./serializer").Parser,
+  FullPacketParser:require("./serializer").FullPacketParser,
   types:proto.types,
   utils:require("./utils")
 };

--- a/src/serializer.js
+++ b/src/serializer.js
@@ -57,7 +57,28 @@ class Parser extends Transform {
   }
 }
 
+
+class FullPacketParser extends Transform {
+  constructor(proto,mainType) {
+    super({ readableObjectMode: true });
+    this.proto=proto;
+    this.mainType=mainType;
+  }
+
+  parsePacketBuffer(buffer) {
+    return this.proto.parsePacketBuffer(this.mainType,buffer);
+  }
+
+  _transform(chunk, enc, cb) {
+    var packet = this.parsePacketBuffer(chunk);
+    if(packet.metadata.size!=chunk.length)
+      throw new Error("Chunk size is "+chunk.length+" but only "+packet.metadata.size+" was read "+chunk.buffer.toString("hex"));
+    this.push(packet);
+  }
+}
+
 module.exports={
   Serializer:Serializer,
-  Parser:Parser
+  Parser:Parser,
+  FullPacketParser:FullPacketParser
 };

--- a/src/serializer.js
+++ b/src/serializer.js
@@ -70,10 +70,19 @@ class FullPacketParser extends Transform {
   }
 
   _transform(chunk, enc, cb) {
-    var packet = this.parsePacketBuffer(chunk);
-    if(packet.metadata.size!=chunk.length)
-      throw new Error("Chunk size is "+chunk.length+" but only "+packet.metadata.size+" was read "+chunk.buffer.toString("hex"));
-    this.push(packet);
+    try {
+      var packet = this.parsePacketBuffer(chunk);
+      if(packet.metadata.size!=chunk.length)
+        cb(new Error("Chunk size is "+chunk.length+" but only "+packet.metadata.size+" was read "+chunk.buffer.toString("hex")));
+      else {
+        this.push(packet);
+        cb();
+      }
+    }
+    catch(e) {
+      cb(e);
+    }
+
   }
 }
 


### PR DESCRIPTION
one way to do #57 

It might make more sense to do that since it avoids the queue if we don't need it.

I'll try the "fixed" datatype option though.

(and need an example to test this)
