### PR TITLE
Unable to resolve JSON files when using Webpack

### DIFF
--- a/src/datatypes/conditional.js
+++ b/src/datatypes/conditional.js
@@ -1,8 +1,8 @@
 const { getField, getFieldInfo, tryDoc, PartialReadError } = require('../utils')
 
 module.exports = {
-  'switch': [readSwitch, writeSwitch, sizeOfSwitch, require('../../ProtoDef/schemas/conditional')['switch']],
-  'option': [readOption, writeOption, sizeOfOption, require('../../ProtoDef/schemas/conditional')['option']]
+  'switch': [readSwitch, writeSwitch, sizeOfSwitch, require('../../ProtoDef/schemas/conditional.json')['switch']],
+  'option': [readOption, writeOption, sizeOfOption, require('../../ProtoDef/schemas/conditional.json')['option']]
 }
 
 function readSwitch (buffer, offset, { compareTo, fields, compareToValue, 'default': defVal }, rootNode) {

--- a/src/datatypes/numeric.js
+++ b/src/datatypes/numeric.js
@@ -92,12 +92,12 @@ const nums = {
 }
 
 const types = Object.keys(nums).reduce((types, num) => {
-  types[num] = generateFunctions(nums[num][0], nums[num][1], nums[num][2], require('../../ProtoDef/schemas/numeric')[num])
+  types[num] = generateFunctions(nums[num][0], nums[num][1], nums[num][2], require('../../ProtoDef/schemas/numeric.json')[num])
   return types
 }, {})
-types['i64'] = [readI64, writeI64, 8, require('../../ProtoDef/schemas/numeric')['i64']]
-types['li64'] = [readLI64, writeLI64, 8, require('../../ProtoDef/schemas/numeric')['li64']]
-types['u64'] = [readU64, writeU64, 8, require('../../ProtoDef/schemas/numeric')['u64']]
-types['lu64'] = [readLU64, writeLU64, 8, require('../../ProtoDef/schemas/numeric')['lu64']]
+types['i64'] = [readI64, writeI64, 8, require('../../ProtoDef/schemas/numeric.json')['i64']]
+types['li64'] = [readLI64, writeLI64, 8, require('../../ProtoDef/schemas/numeric.json')['li64']]
+types['u64'] = [readU64, writeU64, 8, require('../../ProtoDef/schemas/numeric.json')['u64']]
+types['lu64'] = [readLU64, writeLU64, 8, require('../../ProtoDef/schemas/numeric.json')['lu64']]
 
 module.exports = types

--- a/src/datatypes/structures.js
+++ b/src/datatypes/structures.js
@@ -1,9 +1,9 @@
 const { getField, getCount, sendCount, calcCount, tryDoc } = require('../utils')
 
 module.exports = {
-  'array': [readArray, writeArray, sizeOfArray, require('../../ProtoDef/schemas/structures')['array']],
-  'count': [readCount, writeCount, sizeOfCount, require('../../ProtoDef/schemas/structures')['count']],
-  'container': [readContainer, writeContainer, sizeOfContainer, require('../../ProtoDef/schemas/structures')['container']]
+  'array': [readArray, writeArray, sizeOfArray, require('../../ProtoDef/schemas/structures.json')['array']],
+  'count': [readCount, writeCount, sizeOfCount, require('../../ProtoDef/schemas/structures.json')['count']],
+  'container': [readContainer, writeContainer, sizeOfContainer, require('../../ProtoDef/schemas/structures.json')['container']]
 }
 
 function readArray (buffer, offset, typeArgs, rootNode) {

--- a/src/datatypes/utils.js
+++ b/src/datatypes/utils.js
@@ -3,14 +3,14 @@ const assert = require('assert')
 const { getCount, sendCount, calcCount, PartialReadError } = require('../utils')
 
 module.exports = {
-  'varint': [readVarInt, writeVarInt, sizeOfVarInt, require('../../ProtoDef/schemas/utils')['varint']],
-  'bool': [readBool, writeBool, 1, require('../../ProtoDef/schemas/utils')['bool']],
-  'pstring': [readPString, writePString, sizeOfPString, require('../../ProtoDef/schemas/utils')['pstring']],
-  'buffer': [readBuffer, writeBuffer, sizeOfBuffer, require('../../ProtoDef/schemas/utils')['buffer']],
-  'void': [readVoid, writeVoid, 0, require('../../ProtoDef/schemas/utils')['void']],
-  'bitfield': [readBitField, writeBitField, sizeOfBitField, require('../../ProtoDef/schemas/utils')['bitfield']],
-  'cstring': [readCString, writeCString, sizeOfCString, require('../../ProtoDef/schemas/utils')['cstring']],
-  'mapper': [readMapper, writeMapper, sizeOfMapper, require('../../ProtoDef/schemas/utils')['mapper']]
+  'varint': [readVarInt, writeVarInt, sizeOfVarInt, require('../../ProtoDef/schemas/utils.json')['varint']],
+  'bool': [readBool, writeBool, 1, require('../../ProtoDef/schemas/utils.json')['bool']],
+  'pstring': [readPString, writePString, sizeOfPString, require('../../ProtoDef/schemas/utils.json')['pstring']],
+  'buffer': [readBuffer, writeBuffer, sizeOfBuffer, require('../../ProtoDef/schemas/utils.json')['buffer']],
+  'void': [readVoid, writeVoid, 0, require('../../ProtoDef/schemas/utils.json')['void']],
+  'bitfield': [readBitField, writeBitField, sizeOfBitField, require('../../ProtoDef/schemas/utils.json')['bitfield']],
+  'cstring': [readCString, writeCString, sizeOfCString, require('../../ProtoDef/schemas/utils.json')['cstring']],
+  'mapper': [readMapper, writeMapper, sizeOfMapper, require('../../ProtoDef/schemas/utils.json')['mapper']]
 }
 
 function mapperEquality (a, b) {


### PR DESCRIPTION
Since it's not fully supported to resolve a JSON file without extension using require().

I suggest we add '.json' to all require() functions in the following files.

Example from `src/datatypes/conditional.js`:
```javascript
require('../../ProtoDef/schemas/conditional')
```
and change it into:
```javascript
require('../../ProtoDef/schemas/conditional.json')
```

Error i got from my application using webpack:
```
These relative modules were not found:

* ../../ProtoDef/schemas/conditional in ./node_modules/protodef/src/datatypes/conditional.js
* ../../ProtoDef/schemas/numeric in ./node_modules/protodef/src/datatypes/numeric.js        
* ../../ProtoDef/schemas/structures in ./node_modules/protodef/src/datatypes/structures.js  
* ../../ProtoDef/schemas/utils in ./node_modules/protodef/src/datatypes/utils.js
* ./ProtoDef/schemas/conditional in ./node_modules/protodef-validator/index.js
* ./ProtoDef/schemas/numeric in ./node_modules/protodef-validator/index.js
* ./ProtoDef/schemas/structures in ./node_modules/protodef-validator/index.js
* ./ProtoDef/schemas/utils in ./node_modules/protodef-validator/index.js
* ./minecraft-data/data/pc/0.30c/blocks in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/0.30c/protocol in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/0.30c/version in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.10-pre1/protocol in ./node_modules/minecraft-data/data.js      
* ./minecraft-data/data/pc/1.10-pre1/version in ./node_modules/minecraft-data/data.js       
* ./minecraft-data/data/pc/1.10.1/version in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.10.2/version in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.10/biomes in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.10/blocks in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.10/effects in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.10/enchantments in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.10/entities in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.10/instruments in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.10/items in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.10/language in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.10/materials in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.10/protocol in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.10/recipes in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.10/version in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.10/windows in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.11.2/protocolComments in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.11.2/version in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.11/biomes in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.11/blocks in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.11/effects in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.11/enchantments in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.11/entities in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.11/instruments in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.11/items in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.11/language in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.11/materials in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.11/protocol in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.11/recipes in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.11/version in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.11/windows in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.12-pre4/protocol in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.12-pre4/version in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.12.1/protocol in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.12.1/version in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.12.2/protocol in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.12.2/version in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.12/biomes in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.12/blocks in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.12/effects in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.12/enchantments in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.12/entities in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.12/instruments in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.12/items in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.12/language in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.12/materials in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.12/protocol in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.12/recipes in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.12/version in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.12/windows in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.13.1/protocol in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.13.1/version in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.13.2-pre1/protocol in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.13.2-pre1/version in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.13.2-pre2/protocol in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.13.2-pre2/version in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.13.2/biomes in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.13.2/blocks in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.13.2/effects in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.13.2/enchantments in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.13.2/entities in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.13.2/instruments in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.13.2/items in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.13.2/language in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.13.2/materials in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.13.2/protocol in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.13.2/recipes in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.13.2/version in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.13.2/windows in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.13/biomes in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.13/blocks in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.13/effects in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.13/enchantments in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.13/entities in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.13/instruments in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.13/items in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.13/language in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.13/materials in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.13/protocol in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.13/recipes in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.13/version in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.13/windows in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.14.1/protocol in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.14.1/version in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.14.3/protocol in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.14.3/version in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.14.4/protocol in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.14.4/version in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.14/biomes in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.14/entities in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.14/items in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.14/language in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.14/protocol in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.14/recipes in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.14/version in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.7/biomes in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.7/blocks in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.7/effects in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.7/enchantments in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.7/entities in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.7/instruments in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.7/items in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.7/language in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.7/materials in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.7/protocol in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.7/version in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.7/windows in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.8/biomes in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.8/blocks in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.8/effects in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.8/enchantments in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.8/entities in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.8/instruments in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.8/items in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.8/language in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.8/materials in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.8/protocol in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.8/recipes in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.8/version in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.8/windows in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.9.1-pre2/protocol in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.9.1-pre2/version in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.9.2/protocol in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.9.2/protocolComments in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.9.2/version in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.9.4/protocol in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.9.4/version in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.9/biomes in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.9/blocks in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.9/effects in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.9/enchantments in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.9/entities in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.9/instruments in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.9/items in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.9/language in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.9/materials in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.9/protocol in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.9/recipes in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.9/version in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/1.9/windows in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/15w40b/protocol in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/15w40b/version in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/16w20a/protocol in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/16w20a/version in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/16w35a/protocol in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/16w35a/version in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/17w15a/protocol in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/17w15a/version in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/17w18b/protocol in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/17w18b/version in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/17w50a/protocol in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/17w50a/version in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pc/common/protocolVersions in ./node_modules/minecraft-data/index.js
* ./minecraft-data/data/pc/common/versions in ./node_modules/minecraft-data/index.js
* ./minecraft-data/data/pe/0.14/blocks in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pe/0.14/items in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pe/0.14/protocol in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pe/0.14/version in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pe/0.15/blocks in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pe/0.15/items in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pe/0.15/protocol in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pe/0.15/version in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pe/1.0/blocks in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pe/1.0/items in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pe/1.0/version in ./node_modules/minecraft-data/data.js
* ./minecraft-data/data/pe/common/protocolVersions in ./node_modules/minecraft-data/index.js
* ./minecraft-data/data/pe/common/versions in ./node_modules/minecraft-data/index.js
* ./minecraft-data/schemas/effects_schema in ./node_modules/minecraft-data/index.js
* ./minecraft-data/schemas/enchantments_schema in ./node_modules/minecraft-data/index.js
* ./minecraft-data/schemas/entities_schema in ./node_modules/minecraft-data/index.js
* ./minecraft-data/schemas/instruments_schema in ./node_modules/minecraft-data/index.js
* ./minecraft-data/schemas/items_schema in ./node_modules/minecraft-data/index.js
* ./minecraft-data/schemas/materials_schema in ./node_modules/minecraft-data/index.js
* ./minecraft-data/schemas/protocolVersions_schema in ./node_modules/minecraft-data/index.js
* ./minecraft-data/schemas/recipes_schema in ./node_modules/minecraft-data/index.js
* ./minecraft-data/schemas/version_schema in ./node_modules/minecraft-data/index.js
* ./minecraft-data/schemas/windows_schema in ./node_modules/minecraft-data/index.js
 ERROR  Build failed with errors.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```