### PR TITLE
Update readArray at datatypes/structures.js

### DIFF
--- a/src/datatypes/structures.js
+++ b/src/datatypes/structures.js
@@ -9,7 +9,7 @@ module.exports = {
 function readArray (buffer, offset, typeArgs, rootNode) {
   const value = []
   let { count, size } = getCount.call(this, buffer, offset, typeArgs, rootNode)
-  offset += _size
+  offset += size
   for (let i = 0; i < count; i++) {
     const { size: _size, value: _value } = tryDoc(() => this.read(buffer, offset, typeArgs.type, rootNode), i)
     size += _size

--- a/src/datatypes/structures.js
+++ b/src/datatypes/structures.js
@@ -7,21 +7,16 @@ module.exports = {
 }
 
 function readArray (buffer, offset, typeArgs, rootNode) {
-  const results = {
-    value: [],
-    size: 0
-  }
-  let value
+  const value = []
   let { count, size } = getCount.call(this, buffer, offset, typeArgs, rootNode)
-  offset += size
-  results.size += size
+  offset += _size
   for (let i = 0; i < count; i++) {
-    ({ size, value } = tryDoc(() => this.read(buffer, offset, typeArgs.type, rootNode), i))
-    results.size += size
-    offset += size
-    results.value.push(value)
+    const { size: _size, value: _value } = tryDoc(() => this.read(buffer, offset, typeArgs.type, rootNode), i)
+    size += _size
+    offset += _size
+    value[i] = _value
   }
-  return results
+  return { value, size }
 }
 
 function writeArray (value, buffer, offset, typeArgs, rootNode) {


### PR DESCRIPTION
Using Array.push and accessing the object's `result.value` property is performance-cost by itself.

Maybe we should improve that?

- [x] Benchmark it
- [ ] Merge
