### PR TITLE
More interpreter optimizations

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,0 @@
-node_modules
-npm-debug.log

--- a/doc/history.md
+++ b/doc/history.md
@@ -1,5 +1,9 @@
 # History
 
+## 1.7.1
+
+* fix option in compiler
+
 ## 1.7.0
 
 * Add js compiler protodef implementation, that is 10x faster (thanks @Karang for this huge improvement !)

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "tonicExampleFilename": "example.js",
   "license": "MIT",
   "dependencies": {
+    "lodash.clonedeep": "^4.5.0",
     "lodash.get": "^4.4.2",
     "lodash.reduce": "^4.6.0",
     "protodef-validator": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A simple yet powerful way to define binary protocols",
   "main": "index.js",
   "author": "roblabla <robinlambertz.dev@gmail.com>",
+  "sideEffects": false,
   "scripts": {
     "prepare": "require-self",
     "lint": "standard",
@@ -22,7 +23,7 @@
     "readable-stream": "^3.0.3"
   },
   "engines": {
-    "node": ">=6"
+    "node": ">=12"
   },
   "bugs": {
     "url": "https://github.com/ProtoDef-io/node-protodef/issues"
@@ -39,5 +40,10 @@
     "mocha": "^5.2.0",
     "require-self": "^0.1.0",
     "standard": "^12.0.1"
-  }
+  },
+  "files": [
+    "src/",
+    "ProtoDef/schemas/",
+    "*.js"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "protodef",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "A simple yet powerful way to define binary protocols",
   "main": "index.js",
   "author": "roblabla <robinlambertz.dev@gmail.com>",

--- a/src/compiler.js
+++ b/src/compiler.js
@@ -95,14 +95,14 @@ class CompiledProtodef {
   }
 
   createPacketBuffer (type, packet) {
-    const length = tryCatch(() => this.sizeOf(packet, type), this._sizeOfErrorHandler)
+    const length = tryCatch(this.sizeOf.bind(this, packet, type), this._sizeOfErrorHandler)
     const buffer = Buffer.allocUnsafe(length)
-    tryCatch(() => this.write(packet, buffer, 0, type), this._readErrorHandler)
+    tryCatch(this.write.bind(this, packet, buffer, 0, type), this._readErrorHandler)
     return buffer
   }
 
   parsePacketBuffer (type, buffer) {
-    const result = tryCatch(() => this.read(buffer, 0, type), this._writeErrorHandler)
+    const result = tryCatch(this.read.bind(this, buffer, 0, type), this._writeErrorHandler)
     return {
       data: result.value,
       metadata: { size: result.size },
@@ -399,7 +399,7 @@ class SizeOfCompiler extends Compiler {
   addNativeType (type, fn) {
     this.primitiveTypes[type] = `native.${type}`
     if (!isNaN(fn)) {
-      this.native[type] = (value) => { return fn }
+      this.native[type] = () => fn
     } else {
       this.native[type] = fn
     }

--- a/src/compiler.js
+++ b/src/compiler.js
@@ -142,13 +142,13 @@ class CompiledProtodef {
   }
 
   parsePacketBuffer (type, buffer) {
-    const { value, size } = tryCatch(() => this.read(buffer, 0, type),
+    const { value: data, size } = tryCatch(() => this.read(buffer, 0, type),
       (e) => {
         e.message = `Read error for ${e.field} : ${e.message}`
         throw e
       })
     return {
-      data: value,
+      data,
       metadata: { size },
       buffer: buffer.slice(0, size)
     }

--- a/src/datatypes/compiler/conditional.js
+++ b/src/datatypes/compiler/conditional.js
@@ -1,6 +1,10 @@
+const {
+  Enum: { CompilerTypeKind: { PARAMETRIZABLE } }
+} = require('../../utils')
+
 module.exports = {
   Read: {
-    'switch': ['parametrizable', (compiler, struct) => {
+    'switch': [PARAMETRIZABLE, (compiler, struct) => {
       let compare = struct.compareTo ? struct.compareTo : struct.compareToValue
       let args = []
       if (compare.startsWith('$')) args.push(compare)
@@ -17,7 +21,7 @@ module.exports = {
       code += `}`
       return compiler.wrapCode(code, args)
     }],
-    'option': ['parametrizable', (compiler, type) => {
+    'option': [PARAMETRIZABLE, (compiler, type) => {
       let code = 'const {value} = ctx.bool(buffer, offset)\n'
       code += 'if (value) {\n'
       code += '  const { value, size } = ' + compiler.callType(type, 'offset + 1') + '\n'
@@ -29,7 +33,7 @@ module.exports = {
   },
 
   Write: {
-    'switch': ['parametrizable', (compiler, struct) => {
+    'switch': [PARAMETRIZABLE, (compiler, struct) => {
       let compare = struct.compareTo ? struct.compareTo : struct.compareToValue
       let args = []
       if (compare.startsWith('$')) args.push(compare)
@@ -46,7 +50,7 @@ module.exports = {
       code += `}`
       return compiler.wrapCode(code, args)
     }],
-    'option': ['parametrizable', (compiler, type) => {
+    'option': [PARAMETRIZABLE, (compiler, type) => {
       let code = 'if (value != null) {\n'
       code += '  offset = ctx.bool(1, buffer, offset)\n'
       code += '  offset = ' + compiler.callType('value', type) + '\n'
@@ -59,7 +63,7 @@ module.exports = {
   },
 
   SizeOf: {
-    'switch': ['parametrizable', (compiler, struct) => {
+    'switch': [PARAMETRIZABLE, (compiler, struct) => {
       let compare = struct.compareTo ? struct.compareTo : struct.compareToValue
       let args = []
       if (compare.startsWith('$')) args.push(compare)
@@ -76,7 +80,7 @@ module.exports = {
       code += `}`
       return compiler.wrapCode(code, args)
     }],
-    'option': ['parametrizable', (compiler, type) => {
+    'option': [PARAMETRIZABLE, (compiler, type) => {
       let code = 'if (value != null) {\n'
       code += '  return 1 + ' + compiler.callType('value', type) + '\n'
       code += '}\n'

--- a/src/datatypes/compiler/conditional.js
+++ b/src/datatypes/compiler/conditional.js
@@ -24,10 +24,10 @@ module.exports = {
     'option': [PARAMETRIZABLE, (compiler, type) => {
       let code = 'const {value} = ctx.bool(buffer, offset)\n'
       code += 'if (value) {\n'
-      code += '  const { value, size } = ' + compiler.callType(type, 'offset + 1') + '\n'
-      code += '  return { value, size: size + 1 }\n'
+      code += '  const result = ' + compiler.callType(type, 'offset + 1') + '\n'
+      code += '  return new Result(result.value, result.size + 1)\n'
       code += '}\n'
-      code += 'return { value: undefined, size: 1}'
+      code += 'return new Result(undefined, 1)'
       return compiler.wrapCode(code)
     }]
   },

--- a/src/datatypes/compiler/index.js
+++ b/src/datatypes/compiler/index.js
@@ -1,0 +1,30 @@
+const { Enum: { CompilerTypeKind: { NATIVE } } } = require('../../utils')
+const conditionalDatatypes = require('./conditional')
+const structuresDatatypes = require('./structures')
+const utilsDatatypes = require('./utils')
+const sharedDatatypes = require('../shared')
+
+module.exports = {
+  Read: {
+    ...conditionalDatatypes.Read,
+    ...structuresDatatypes.Read,
+    ...utilsDatatypes.Read
+  },
+  Write: {
+    ...conditionalDatatypes.Write,
+    ...structuresDatatypes.Write,
+    ...utilsDatatypes.Write
+  },
+  SizeOf: {
+    ...conditionalDatatypes.SizeOf,
+    ...structuresDatatypes.SizeOf,
+    ...utilsDatatypes.SizeOf
+  }
+}
+
+for (const k in sharedDatatypes) {
+  const [ read, write, sizeOf ] = sharedDatatypes[k]
+  module.exports.Read[k] = [NATIVE, read]
+  module.exports.Write[k] = [NATIVE, write]
+  module.exports.SizeOf[k] = [NATIVE, sizeOf]
+}

--- a/src/datatypes/compiler/structures.js
+++ b/src/datatypes/compiler/structures.js
@@ -21,7 +21,7 @@ module.exports = {
       code += '  data.push(elem.value)\n'
       code += '  size += elem.size\n'
       code += '}\n'
-      code += 'return { value: data, size }'
+      code += 'return new Result(data, size)'
       return compiler.wrapCode(code)
     }],
     'count': [PARAMETRIZABLE, (compiler, type) => {
@@ -60,7 +60,7 @@ module.exports = {
       const sizes = offsetExpr.split(' + ')
       sizes.shift()
       if (sizes.length === 0) sizes.push('0')
-      code += 'return { value: { ' + names.join(', ') + ' }, size: ' + sizes.join(' + ') + '}'
+      code += 'return new Result({ ' + names.join(', ') + ' }, ' + sizes.join(' + ') + ')'
       return compiler.wrapCode(code)
     }]
   },

--- a/src/datatypes/compiler/structures.js
+++ b/src/datatypes/compiler/structures.js
@@ -1,6 +1,10 @@
+const {
+  Enum: { CompilerTypeKind: { PARAMETRIZABLE } }
+} = require('../../utils')
+
 module.exports = {
   Read: {
-    'array': ['parametrizable', (compiler, array) => {
+    'array': [PARAMETRIZABLE, (compiler, array) => {
       let code = ''
       if (array.countType) {
         code += 'const { value: count, size: countSize } = ' + compiler.callType(array.countType) + '\n'
@@ -20,11 +24,11 @@ module.exports = {
       code += 'return { value: data, size }'
       return compiler.wrapCode(code)
     }],
-    'count': ['parametrizable', (compiler, type) => {
+    'count': [PARAMETRIZABLE, (compiler, type) => {
       let code = 'return ' + compiler.callType(type.type)
       return compiler.wrapCode(code)
     }],
-    'container': ['parametrizable', (compiler, values) => {
+    'container': [PARAMETRIZABLE, (compiler, values) => {
       values = containerInlining(values)
 
       let code = ''
@@ -62,7 +66,7 @@ module.exports = {
   },
 
   Write: {
-    'array': ['parametrizable', (compiler, array) => {
+    'array': [PARAMETRIZABLE, (compiler, array) => {
       let code = ''
       if (array.countType) {
         code += 'offset = ' + compiler.callType('value.length', array.countType) + '\n'
@@ -75,11 +79,11 @@ module.exports = {
       code += 'return offset'
       return compiler.wrapCode(code)
     }],
-    'count': ['parametrizable', (compiler, type) => {
+    'count': [PARAMETRIZABLE, (compiler, type) => {
       let code = 'return ' + compiler.callType('value', type.type)
       return compiler.wrapCode(code)
     }],
-    'container': ['parametrizable', (compiler, values) => {
+    'container': [PARAMETRIZABLE, (compiler, values) => {
       values = containerInlining(values)
       let code = ''
       for (const i in values) {
@@ -106,7 +110,7 @@ module.exports = {
   },
 
   SizeOf: {
-    'array': ['parametrizable', (compiler, array) => {
+    'array': [PARAMETRIZABLE, (compiler, array) => {
       let code = ''
       if (array.countType) {
         code += 'let size = ' + compiler.callType('value.length', array.countType) + '\n'
@@ -125,11 +129,11 @@ module.exports = {
       code += 'return size'
       return compiler.wrapCode(code)
     }],
-    'count': ['parametrizable', (compiler, type) => {
+    'count': [PARAMETRIZABLE, (compiler, type) => {
       let code = 'return ' + compiler.callType('value', type.type)
       return compiler.wrapCode(code)
     }],
-    'container': ['parametrizable', (compiler, values) => {
+    'container': [PARAMETRIZABLE, (compiler, values) => {
       values = containerInlining(values)
       let code = 'let size = 0\n'
       for (const i in values) {

--- a/src/datatypes/compiler/structures.js
+++ b/src/datatypes/compiler/structures.js
@@ -14,6 +14,7 @@ module.exports = {
       } else {
         throw new Error('Array must contain either count or countType')
       }
+      code += 'if (count > 0xffffff) throw new Error("array size is abnormally large, not reading: " + count)\n'
       code += 'const data = []\n'
       code += 'let size = countSize\n'
       code += 'for (let i = 0; i < count; i++) {\n'

--- a/src/datatypes/compiler/utils.js
+++ b/src/datatypes/compiler/utils.js
@@ -18,7 +18,7 @@ module.exports = {
       code += 'if (offset + count > buffer.length) {\n'
       code += '  throw new PartialReadError("Missing characters in string, found size is " + buffer.length + " expected size was " + (offset + count))\n'
       code += '}\n'
-      code += 'return { value: buffer.toString(\'utf8\', offset, offset + count), size: count + countSize }'
+      code += 'return new Result(buffer.toString(\'utf8\', offset, offset + count), count + countSize)'
       return compiler.wrapCode(code)
     }],
     'buffer': [PARAMETRIZABLE, (compiler, buffer) => {
@@ -35,7 +35,7 @@ module.exports = {
       code += 'if (offset + count > buffer.length) {\n'
       code += '  throw new PartialReadError()\n'
       code += '}\n'
-      code += 'return { value: buffer.slice(offset, offset + count), size: count + countSize }'
+      code += 'return new Result(buffer.slice(offset, offset + count), count + countSize)'
       return compiler.wrapCode(code)
     }],
     'bitfield': [PARAMETRIZABLE, (compiler, values) => {
@@ -59,12 +59,12 @@ module.exports = {
         if (name === trueName) names.push(name)
         else names.push(`${name}: ${trueName}`)
       }
-      code += 'return { value: { ' + names.join(', ') + ` }, size: ${totalBytes} }`
+      code += 'return new Result({ ' + names.join(', ') + ` }, ${totalBytes})`
       return compiler.wrapCode(code)
     }],
     'mapper': [PARAMETRIZABLE, (compiler, mapper) => {
       let code = 'const { value, size } = ' + compiler.callType(mapper.type) + '\n'
-      code += 'return { value: ' + JSON.stringify(sanitizeMappings(mapper.mappings)) + '[value], size }'
+      code += 'return new Result(' + JSON.stringify(sanitizeMappings(mapper.mappings)) + '[value], size)'
       return compiler.wrapCode(code)
     }]
   },

--- a/src/datatypes/compiler/utils.js
+++ b/src/datatypes/compiler/utils.js
@@ -1,6 +1,10 @@
+const {
+  Enum: { CompilerTypeKind: { PARAMETRIZABLE } }
+} = require('../../utils')
+
 module.exports = {
   Read: {
-    'pstring': ['parametrizable', (compiler, string) => {
+    'pstring': [PARAMETRIZABLE, (compiler, string) => {
       let code = ''
       if (string.countType) {
         code += 'const { value: count, size: countSize } = ' + compiler.callType(string.countType) + '\n'
@@ -17,7 +21,7 @@ module.exports = {
       code += 'return { value: buffer.toString(\'utf8\', offset, offset + count), size: count + countSize }'
       return compiler.wrapCode(code)
     }],
-    'buffer': ['parametrizable', (compiler, buffer) => {
+    'buffer': [PARAMETRIZABLE, (compiler, buffer) => {
       let code = ''
       if (buffer.countType) {
         code += 'const { value: count, size: countSize } = ' + compiler.callType(buffer.countType) + '\n'
@@ -34,7 +38,7 @@ module.exports = {
       code += 'return { value: buffer.slice(offset, offset + count), size: count + countSize }'
       return compiler.wrapCode(code)
     }],
-    'bitfield': ['parametrizable', (compiler, values) => {
+    'bitfield': [PARAMETRIZABLE, (compiler, values) => {
       let code = ''
       const totalBytes = Math.ceil(values.reduce((acc, { size }) => acc + size, 0) / 8)
       code += `if ( offset + ${totalBytes} > buffer.length) { throw new PartialReadError() }\n`
@@ -58,7 +62,7 @@ module.exports = {
       code += 'return { value: { ' + names.join(', ') + ` }, size: ${totalBytes} }`
       return compiler.wrapCode(code)
     }],
-    'mapper': ['parametrizable', (compiler, mapper) => {
+    'mapper': [PARAMETRIZABLE, (compiler, mapper) => {
       let code = 'const { value, size } = ' + compiler.callType(mapper.type) + '\n'
       code += 'return { value: ' + JSON.stringify(sanitizeMappings(mapper.mappings)) + '[value], size }'
       return compiler.wrapCode(code)
@@ -66,7 +70,7 @@ module.exports = {
   },
 
   Write: {
-    'pstring': ['parametrizable', (compiler, string) => {
+    'pstring': [PARAMETRIZABLE, (compiler, string) => {
       let code = 'const length = Buffer.byteLength(value, \'utf8\')\n'
       if (string.countType) {
         code += 'offset = ' + compiler.callType('length', string.countType) + '\n'
@@ -77,7 +81,7 @@ module.exports = {
       code += 'return offset + length'
       return compiler.wrapCode(code)
     }],
-    'buffer': ['parametrizable', (compiler, buffer) => {
+    'buffer': [PARAMETRIZABLE, (compiler, buffer) => {
       let code = ''
       if (buffer.countType) {
         code += 'offset = ' + compiler.callType('value.length', buffer.countType) + '\n'
@@ -88,7 +92,7 @@ module.exports = {
       code += 'return offset + value.length'
       return compiler.wrapCode(code)
     }],
-    'bitfield': ['parametrizable', (compiler, values) => {
+    'bitfield': [PARAMETRIZABLE, (compiler, values) => {
       let toWrite = ''
       let bits = 0
       let code = ''
@@ -116,7 +120,7 @@ module.exports = {
       code += 'return offset'
       return compiler.wrapCode(code)
     }],
-    'mapper': ['parametrizable', (compiler, mapper) => {
+    'mapper': [PARAMETRIZABLE, (compiler, mapper) => {
       const mappings = JSON.stringify(swapMappings(mapper.mappings))
       const code = 'return ' + compiler.callType(`${mappings}[value]`, mapper.type)
       return compiler.wrapCode(code)
@@ -124,7 +128,7 @@ module.exports = {
   },
 
   SizeOf: {
-    'pstring': ['parametrizable', (compiler, string) => {
+    'pstring': [PARAMETRIZABLE, (compiler, string) => {
       let code = 'let size = Buffer.byteLength(value, \'utf8\')\n'
       if (string.countType) {
         code += 'size += ' + compiler.callType('size', string.countType) + '\n'
@@ -134,7 +138,7 @@ module.exports = {
       code += 'return size'
       return compiler.wrapCode(code)
     }],
-    'buffer': ['parametrizable', (compiler, buffer) => {
+    'buffer': [PARAMETRIZABLE, (compiler, buffer) => {
       let code = 'let size = value.length\n'
       if (buffer.countType) {
         code += 'size += ' + compiler.callType('size', buffer.countType) + '\n'
@@ -144,11 +148,11 @@ module.exports = {
       code += 'return size'
       return compiler.wrapCode(code)
     }],
-    'bitfield': ['parametrizable', (compiler, values) => {
+    'bitfield': [PARAMETRIZABLE, (compiler, values) => {
       const totalBytes = Math.ceil(values.reduce((acc, { size }) => acc + size, 0) / 8)
       return `${totalBytes}`
     }],
-    'mapper': ['parametrizable', (compiler, mapper) => {
+    'mapper': [PARAMETRIZABLE, (compiler, mapper) => {
       const mappings = JSON.stringify(swapMappings(mapper.mappings))
       const code = 'return ' + compiler.callType(`${mappings}[value]`, mapper.type)
       return compiler.wrapCode(code)

--- a/src/datatypes/conditional.js
+++ b/src/datatypes/conditional.js
@@ -1,56 +1,69 @@
 const { getField, getFieldInfo, tryDoc, PartialReadError } = require('../utils')
 
-module.exports = {
-  'switch': [readSwitch, writeSwitch, sizeOfSwitch, require('../../ProtoDef/schemas/conditional.json')['switch']],
-  'option': [readOption, writeOption, sizeOfOption, require('../../ProtoDef/schemas/conditional.json')['option']]
-}
-
 function readSwitch (buffer, offset, { compareTo, fields, compareToValue, 'default': defVal }, rootNode) {
   compareTo = compareToValue !== undefined ? compareToValue : getField(compareTo, rootNode)
-  if (typeof fields[compareTo] === 'undefined' && typeof defVal === 'undefined') { throw new Error(compareTo + ' has no associated fieldInfo in switch') }
-
-  const caseDefault = typeof fields[compareTo] === 'undefined'
-  const resultingType = caseDefault ? defVal : fields[compareTo]
-  const fieldInfo = getFieldInfo(resultingType)
-  return tryDoc(() => this.read(buffer, offset, fieldInfo, rootNode), caseDefault ? 'default' : compareTo)
+  if (fields[compareTo] === undefined) {
+    compareTo = 'default'
+    fields[compareTo] = defVal
+    if (defVal === undefined) {
+      throw new Error(`${compareTo} has no associated fieldInfo in switch`)
+    }
+  }
+  const fieldInfo = getFieldInfo(fields[compareTo])
+  return tryDoc(() => this.read(buffer, offset, fieldInfo, rootNode), compareTo)
 }
 
 function writeSwitch (value, buffer, offset, { compareTo, fields, compareToValue, 'default': defVal }, rootNode) {
   compareTo = compareToValue !== undefined ? compareToValue : getField(compareTo, rootNode)
-  if (typeof fields[compareTo] === 'undefined' && typeof defVal === 'undefined') { throw new Error(compareTo + ' has no associated fieldInfo in switch') }
-
-  const caseDefault = typeof fields[compareTo] === 'undefined'
-  const fieldInfo = getFieldInfo(caseDefault ? defVal : fields[compareTo])
-  return tryDoc(() => this.write(value, buffer, offset, fieldInfo, rootNode), caseDefault ? 'default' : compareTo)
+  if (fields[compareTo] === undefined) {
+    compareTo = 'default'
+    fields[compareTo] = defVal
+    if (defVal === undefined) {
+      throw new Error(`${compareTo} has no associated fieldInfo in switch`)
+    }
+  }
+  const fieldInfo = getFieldInfo(fields[compareTo])
+  return tryDoc(() => this.write(value, buffer, offset, fieldInfo, rootNode), compareTo)
 }
 
 function sizeOfSwitch (value, { compareTo, fields, compareToValue, 'default': defVal }, rootNode) {
   compareTo = compareToValue !== undefined ? compareToValue : getField(compareTo, rootNode)
-  if (typeof fields[compareTo] === 'undefined' && typeof defVal === 'undefined') { throw new Error(compareTo + ' has no associated fieldInfo in switch') }
-
-  const caseDefault = typeof fields[compareTo] === 'undefined'
-  const fieldInfo = getFieldInfo(caseDefault ? defVal : fields[compareTo])
-  return tryDoc(() => this.sizeOf(value, fieldInfo, rootNode), caseDefault ? 'default' : compareTo)
+  if (fields[compareTo] === undefined) {
+    compareTo = 'default'
+    fields[compareTo] = defVal
+    if (defVal === undefined) {
+      throw new Error(`${compareTo} has no associated fieldInfo in switch`)
+    }
+  }
+  const fieldInfo = getFieldInfo(fields[compareTo])
+  return tryDoc(() => this.sizeOf(value, fieldInfo, rootNode), compareTo)
 }
 
 function readOption (buffer, offset, typeArgs, context) {
   if (buffer.length < offset + 1) { throw new PartialReadError() }
-  const val = buffer.readUInt8(offset++)
-  if (val !== 0) {
+  const isPresent = buffer.readUInt8(offset++) !== 0
+  if (isPresent) {
     const retval = this.read(buffer, offset, typeArgs, context)
     retval.size++
     return retval
-  } else { return { size: 1 } }
+  }
+  return { size: 1 }
 }
 
 function writeOption (value, buffer, offset, typeArgs, context) {
-  if (value != null) {
-    buffer.writeUInt8(1, offset++)
+  const isPresent = value != null
+  buffer.writeUInt8(isPresent & 1, offset++)
+  if (isPresent) {
     offset = this.write(value, buffer, offset, typeArgs, context)
-  } else { buffer.writeUInt8(0, offset++) }
+  }
   return offset
 }
 
 function sizeOfOption (value, typeArgs, context) {
-  return value == null ? 1 : this.sizeOf(value, typeArgs, context) + 1
+  return (value != null && this.sizeOf(value, typeArgs, context)) + 1
+}
+
+module.exports = {
+  'switch': [readSwitch, writeSwitch, sizeOfSwitch, require('../../ProtoDef/schemas/conditional.json')['switch']],
+  'option': [readOption, writeOption, sizeOfOption, require('../../ProtoDef/schemas/conditional.json')['option']]
 }

--- a/src/datatypes/interpreter/conditional.js
+++ b/src/datatypes/interpreter/conditional.js
@@ -1,4 +1,4 @@
-const { getField, getFieldInfo, tryDoc, PartialReadError } = require('../../utils')
+const { getField, getFieldInfo, tryDoc, PartialReadError, Result } = require('../../utils')
 const schema = require('../../../ProtoDef/schemas/conditional.json')
 
 function readSwitch (buffer, offset, { compareTo, fields, compareToValue, 'default': defVal }, rootNode) {
@@ -11,7 +11,7 @@ function readSwitch (buffer, offset, { compareTo, fields, compareToValue, 'defau
     }
   }
   const fieldInfo = getFieldInfo(fields[compareTo])
-  return tryDoc(() => this.read(buffer, offset, fieldInfo, rootNode), compareTo)
+  return tryDoc(this.read.bind(this, buffer, offset, fieldInfo, rootNode), compareTo)
 }
 
 function writeSwitch (value, buffer, offset, { compareTo, fields, compareToValue, 'default': defVal }, rootNode) {
@@ -24,7 +24,7 @@ function writeSwitch (value, buffer, offset, { compareTo, fields, compareToValue
     }
   }
   const fieldInfo = getFieldInfo(fields[compareTo])
-  return tryDoc(() => this.write(value, buffer, offset, fieldInfo, rootNode), compareTo)
+  return tryDoc(this.write.bind(this, value, buffer, offset, fieldInfo, rootNode), compareTo)
 }
 
 function sizeOfSwitch (value, { compareTo, fields, compareToValue, 'default': defVal }, rootNode) {
@@ -37,7 +37,7 @@ function sizeOfSwitch (value, { compareTo, fields, compareToValue, 'default': de
     }
   }
   const fieldInfo = getFieldInfo(fields[compareTo])
-  return tryDoc(() => this.sizeOf(value, fieldInfo, rootNode), compareTo)
+  return tryDoc(this.sizeOf.bind(this, value, fieldInfo, rootNode), compareTo)
 }
 
 function readOption (buffer, offset, typeArgs, context) {
@@ -48,7 +48,7 @@ function readOption (buffer, offset, typeArgs, context) {
     retval.size++
     return retval
   }
-  return { size: 1 }
+  return new Result(undefined, 1)
 }
 
 function writeOption (value, buffer, offset, typeArgs, context) {

--- a/src/datatypes/interpreter/conditional.js
+++ b/src/datatypes/interpreter/conditional.js
@@ -1,4 +1,5 @@
-const { getField, getFieldInfo, tryDoc, PartialReadError } = require('../utils')
+const { getField, getFieldInfo, tryDoc, PartialReadError } = require('../../utils')
+const schema = require('../../../ProtoDef/schemas/conditional.json')
 
 function readSwitch (buffer, offset, { compareTo, fields, compareToValue, 'default': defVal }, rootNode) {
   compareTo = compareToValue !== undefined ? compareToValue : getField(compareTo, rootNode)
@@ -64,6 +65,6 @@ function sizeOfOption (value, typeArgs, context) {
 }
 
 module.exports = {
-  'switch': [readSwitch, writeSwitch, sizeOfSwitch, require('../../ProtoDef/schemas/conditional.json')['switch']],
-  'option': [readOption, writeOption, sizeOfOption, require('../../ProtoDef/schemas/conditional.json')['option']]
+  'switch': [readSwitch, writeSwitch, sizeOfSwitch, schema['switch']],
+  'option': [readOption, writeOption, sizeOfOption, schema['option']]
 }

--- a/src/datatypes/interpreter/index.js
+++ b/src/datatypes/interpreter/index.js
@@ -1,0 +1,11 @@
+const conditionalDatatypes = require('./conditional')
+const structuresDatatypes = require('./structures')
+const utilsDatatypes = require('./utils')
+const sharedDatatypes = require('../shared')
+
+module.exports = {
+  ...conditionalDatatypes,
+  ...structuresDatatypes,
+  ...utilsDatatypes,
+  ...sharedDatatypes
+}

--- a/src/datatypes/interpreter/structures.js
+++ b/src/datatypes/interpreter/structures.js
@@ -50,6 +50,7 @@ function readContainer (buffer, offset, typeArgs, context) {
   let size = 0
   Object.defineProperty(value, '..', {
     enumerable: false,
+    configurable: true,
     value: context
   })
   for (const { type, name, anon } of typeArgs) {
@@ -61,6 +62,7 @@ function readContainer (buffer, offset, typeArgs, context) {
         for (const k in v) {
           value[k] = v[k]
         }
+        continue
       }
       value[name] = v
     }, name || 'unknown')

--- a/src/datatypes/interpreter/structures.js
+++ b/src/datatypes/interpreter/structures.js
@@ -62,7 +62,7 @@ function readContainer (buffer, offset, typeArgs, context) {
         for (const k in v) {
           value[k] = v[k]
         }
-        continue
+        return
       }
       value[name] = v
     }, name || 'unknown')

--- a/src/datatypes/interpreter/structures.js
+++ b/src/datatypes/interpreter/structures.js
@@ -1,4 +1,5 @@
-const { getField, getCount, sendCount, calcCount, tryDoc } = require('../utils')
+const { getField, getCount, sendCount, calcCount, tryDoc } = require('../../utils')
+const schema = require('../../../ProtoDef/schemas/structures.json')
 
 function readArray (buffer, offset, typeArgs, rootNode) {
   const value = []
@@ -94,7 +95,7 @@ function sizeOfContainer (value, typeArgs, context) {
 }
 
 module.exports = {
-  'array': [readArray, writeArray, sizeOfArray, require('../../ProtoDef/schemas/structures.json')['array']],
-  'count': [readCount, writeCount, sizeOfCount, require('../../ProtoDef/schemas/structures.json')['count']],
-  'container': [readContainer, writeContainer, sizeOfContainer, require('../../ProtoDef/schemas/structures.json')['container']]
+  'array': [readArray, writeArray, sizeOfArray, schema['array']],
+  'count': [readCount, writeCount, sizeOfCount, schema['count']],
+  'container': [readContainer, writeContainer, sizeOfContainer, schema['container']]
 }

--- a/src/datatypes/interpreter/utils.js
+++ b/src/datatypes/interpreter/utils.js
@@ -36,8 +36,7 @@ function readPString (buffer, offset, typeArgs, rootNode) {
   const cursor = offset + size
   const strEnd = cursor + count
   if (strEnd > buffer.length) {
-    throw new PartialReadError('Missing characters in string, found size is ' +
-    buffer.length + ' expected size was ' + strEnd)
+    throw new PartialReadError(`Missing characters in string, found size is ${buffer.length} expected size was ${strEnd}`)
   }
   return new Result(buffer.toString('utf8', cursor, strEnd), size + count)
 }

--- a/src/datatypes/shared/index.js
+++ b/src/datatypes/shared/index.js
@@ -1,0 +1,5 @@
+const numeric = require('./numeric')
+const utils = require('./utils')
+
+// There's no need to compile these types, just optimize it instead
+module.exports = { ...numeric, ...utils }

--- a/src/datatypes/shared/numeric.js
+++ b/src/datatypes/shared/numeric.js
@@ -1,4 +1,4 @@
-const { PartialReadError } = require('../utils')
+const { PartialReadError } = require('../../utils')
 
 function readI64 (buffer, offset) {
   if (offset + 8 > buffer.length) { throw new PartialReadError() }
@@ -76,10 +76,10 @@ const nums = {
 }
 
 const types = {
-  i64: [readI64, writeI64, 8, require('../../ProtoDef/schemas/numeric.json')['i64']],
-  li64: [readLI64, writeLI64, 8, require('../../ProtoDef/schemas/numeric.json')['li64']],
-  u64: [readU64, writeU64, 8, require('../../ProtoDef/schemas/numeric.json')['u64']],
-  lu64: [readLU64, writeLU64, 8, require('../../ProtoDef/schemas/numeric.json')['lu64']]
+  i64: [readI64, writeI64, 8, require('../../../ProtoDef/schemas/numeric.json')['i64']],
+  li64: [readLI64, writeLI64, 8, require('../../../ProtoDef/schemas/numeric.json')['li64']],
+  u64: [readU64, writeU64, 8, require('../../../ProtoDef/schemas/numeric.json')['u64']],
+  lu64: [readLU64, writeLU64, 8, require('../../../ProtoDef/schemas/numeric.json')['lu64']]
 }
 
 for (const num in nums) {
@@ -96,7 +96,7 @@ for (const num in nums) {
       return buffer[bufferWriter](value, offset)
     },
     size,
-    require('../../ProtoDef/schemas/numeric.json')[num]
+    require('../../../ProtoDef/schemas/numeric.json')[num]
   ]
 }
 

--- a/src/datatypes/shared/utils.js
+++ b/src/datatypes/shared/utils.js
@@ -1,6 +1,7 @@
 const { PartialReadError, Result } = require('../../utils')
 const schema = require('../../../ProtoDef/schemas/utils.json')
 
+const LOG2 = Math.log2(0x7F)
 function readVarInt (buffer, offset) {
   let value = 0
   let size = 0
@@ -14,12 +15,7 @@ function readVarInt (buffer, offset) {
 }
 
 function sizeOfVarInt (value) {
-  let size = 1
-  while (value & ~0x7F) {
-    size++
-    value >>>= 7
-  }
-  return size
+  return value >= 0 ? Math.ceil(Math.log2(Math.max(value, 127)) / LOG2) : 5
 }
 
 function writeVarInt (value, buffer, offset) {
@@ -41,7 +37,7 @@ function writeBool (value, buffer, offset) {
 }
 
 function readVoid () {
-  return new Result()
+  return new Result(undefined, 0)
 }
 
 function writeVoid (value, buffer, offset) {

--- a/src/datatypes/shared/utils.js
+++ b/src/datatypes/shared/utils.js
@@ -1,0 +1,82 @@
+const { PartialReadError } = require('../../utils')
+const schema = require('../../../ProtoDef/schemas/utils.json')
+
+function readVarInt (buffer, offset) {
+  let value = 0
+  let size = 0
+  while (true) {
+    const v = buffer[offset + size]
+    value |= (v & 0x7F) << (size++ * 7)
+    if ((v & 0x80) === 0) break
+  }
+  if (offset + size > buffer.length) throw new PartialReadError()
+  return { value, size }
+}
+
+function sizeOfVarInt (value) {
+  let size = 1
+  while (value & ~0x7F) {
+    size++
+    value >>>= 7
+  }
+  return size
+}
+
+function writeVarInt (value, buffer, offset) {
+  while (value & ~0x7F) {
+    buffer[offset++] = (value & 0xFF) | 0x80
+    value >>>= 7
+  }
+  buffer[offset++] = value | 0
+  return offset
+}
+
+function readBool (buffer, offset) {
+  if (buffer.length <= offset) throw new PartialReadError()
+  return {
+    value: buffer[offset] === 1,
+    size: 1
+  }
+}
+
+function writeBool (value, buffer, offset) {
+  buffer.writeUInt8(value & 1, offset++)
+  return offset
+}
+
+function readVoid () {
+  return {
+    value: undefined,
+    size: 0
+  }
+}
+
+function writeVoid (value, buffer, offset) {
+  return offset
+}
+
+function readCString (buffer, offset) {
+  const index = buffer.indexOf(0x00)
+  if (index === -1) throw new PartialReadError()
+  return {
+    value: buffer.toString('utf8', offset, index),
+    size: index - offset + 1
+  }
+}
+
+function writeCString (value, buffer, offset) {
+  const length = Buffer.byteLength(value, 'utf8')
+  buffer.write(value, offset, length, 'utf8')
+  return buffer.writeInt8(0x00, offset + length)
+}
+
+function sizeOfCString (value) {
+  return Buffer.byteLength(value, 'utf8') + 1
+}
+
+module.exports = {
+  'varint': [readVarInt, writeVarInt, sizeOfVarInt, schema['varint']],
+  'bool': [readBool, writeBool, 1, schema['bool']],
+  'void': [readVoid, writeVoid, 0, schema['void']],
+  'cstring': [readCString, writeCString, sizeOfCString, schema['cstring']]
+}

--- a/src/datatypes/shared/utils.js
+++ b/src/datatypes/shared/utils.js
@@ -1,4 +1,4 @@
-const { PartialReadError } = require('../../utils')
+const { PartialReadError, Result } = require('../../utils')
 const schema = require('../../../ProtoDef/schemas/utils.json')
 
 function readVarInt (buffer, offset) {
@@ -10,7 +10,7 @@ function readVarInt (buffer, offset) {
     if ((v & 0x80) === 0) break
   }
   if (offset + size > buffer.length) throw new PartialReadError()
-  return { value, size }
+  return new Result(value, size)
 }
 
 function sizeOfVarInt (value) {
@@ -33,10 +33,7 @@ function writeVarInt (value, buffer, offset) {
 
 function readBool (buffer, offset) {
   if (buffer.length <= offset) throw new PartialReadError()
-  return {
-    value: buffer[offset] === 1,
-    size: 1
-  }
+  return new Result(buffer[offset] === 1, 1)
 }
 
 function writeBool (value, buffer, offset) {
@@ -44,10 +41,7 @@ function writeBool (value, buffer, offset) {
 }
 
 function readVoid () {
-  return {
-    value: undefined,
-    size: 0
-  }
+  return new Result()
 }
 
 function writeVoid (value, buffer, offset) {
@@ -57,10 +51,7 @@ function writeVoid (value, buffer, offset) {
 function readCString (buffer, offset) {
   const index = buffer.indexOf(0x00)
   if (index === -1) throw new PartialReadError()
-  return {
-    value: buffer.toString('utf8', offset, index),
-    size: index - offset + 1
-  }
+  return new Result(buffer.toString('utf8', offset, index), index - offset + 1)
 }
 
 function writeCString (value, buffer, offset) {

--- a/src/datatypes/shared/utils.js
+++ b/src/datatypes/shared/utils.js
@@ -40,8 +40,7 @@ function readBool (buffer, offset) {
 }
 
 function writeBool (value, buffer, offset) {
-  buffer.writeUInt8(value & 1, offset++)
-  return offset
+  return buffer.writeUInt8(value & 1, offset)
 }
 
 function readVoid () {

--- a/src/datatypes/structures.js
+++ b/src/datatypes/structures.js
@@ -1,76 +1,31 @@
 const { getField, getCount, sendCount, calcCount, tryDoc } = require('../utils')
 
-module.exports = {
-  'array': [readArray, writeArray, sizeOfArray, require('../../ProtoDef/schemas/structures.json')['array']],
-  'count': [readCount, writeCount, sizeOfCount, require('../../ProtoDef/schemas/structures.json')['count']],
-  'container': [readContainer, writeContainer, sizeOfContainer, require('../../ProtoDef/schemas/structures.json')['container']]
-}
-
 function readArray (buffer, offset, typeArgs, rootNode) {
-  const results = {
-    value: [],
-    size: 0
-  }
-  let value
+  const value = []
   let { count, size } = getCount.call(this, buffer, offset, typeArgs, rootNode)
   offset += size
-  results.size += size
   for (let i = 0; i < count; i++) {
-    ({ size, value } = tryDoc(() => this.read(buffer, offset, typeArgs.type, rootNode), i))
-    results.size += size
-    offset += size
-    results.value.push(value)
+    const { size: s, value: v } = tryDoc(() => this.read(buffer, offset, typeArgs.type, rootNode), i)
+    size += s
+    offset += s
+    value.push(v)
   }
-  return results
+  return { value, size }
 }
 
 function writeArray (value, buffer, offset, typeArgs, rootNode) {
   offset = sendCount.call(this, value.length, buffer, offset, typeArgs, rootNode)
-  return value.reduce((offset, v, index) => tryDoc(() => this.write(v, buffer, offset, typeArgs.type, rootNode), index), offset)
+  for (let i = 0, l = value.length; i < l; i++) {
+    offset = tryDoc(() => this.write(value[i], buffer, offset, typeArgs.type, rootNode), i)
+  }
+  return offset
 }
 
 function sizeOfArray (value, typeArgs, rootNode) {
   let size = calcCount.call(this, value.length, typeArgs, rootNode)
-  size = value.reduce((size, v, index) => tryDoc(() => size + this.sizeOf(v, typeArgs.type, rootNode), index), size)
-  return size
-}
-
-function readContainer (buffer, offset, typeArgs, context) {
-  const results = {
-    value: { '..': context },
-    size: 0
+  for (let i = 0, l = value.length; i < l; i++) {
+    size += tryDoc(() => this.sizeOf(value[i], typeArgs.type, rootNode), i)
   }
-  typeArgs.forEach(({ type, name, anon }) => {
-    tryDoc(() => {
-      const readResults = this.read(buffer, offset, type, results.value)
-      results.size += readResults.size
-      offset += readResults.size
-      if (anon) {
-        if (readResults.value !== undefined) {
-          Object.keys(readResults.value).forEach(key => {
-            results.value[key] = readResults.value[key]
-          })
-        }
-      } else { results.value[name] = readResults.value }
-    }, name || 'unknown')
-  })
-  delete results.value['..']
-  return results
-}
-
-function writeContainer (value, buffer, offset, typeArgs, context) {
-  value['..'] = context
-  offset = typeArgs.reduce((offset, { type, name, anon }) =>
-    tryDoc(() => this.write(anon ? value : value[name], buffer, offset, type, value), name || 'unknown'), offset)
-  delete value['..']
-  return offset
-}
-
-function sizeOfContainer (value, typeArgs, context) {
-  value['..'] = context
-  const size = typeArgs.reduce((size, { type, name, anon }) =>
-    size + tryDoc(() => this.sizeOf(anon ? value : value[name], type, value), name || 'unknown'), 0)
-  delete value['..']
   return size
 }
 
@@ -87,4 +42,59 @@ function writeCount (value, buffer, offset, { countFor, type }, rootNode) {
 function sizeOfCount (value, { countFor, type }, rootNode) {
   // TODO : should I use value or getField().length ?
   return this.sizeOf(getField(countFor, rootNode).length, type, rootNode)
+}
+
+function readContainer (buffer, offset, typeArgs, context) {
+  const value = {}
+  let size = 0
+  Object.defineProperty(value, '..', {
+    enumerable: false,
+    value: context
+  })
+  for (const { type, name, anon } of typeArgs) {
+    tryDoc(() => {
+      const { size: s, value: v } = this.read(buffer, offset, type, value)
+      size += s
+      offset += s
+      if (anon && v !== undefined) {
+        for (const k in v) {
+          value[k] = v[k]
+        }
+      }
+      value[name] = v
+    }, name || 'unknown')
+  }
+  context = undefined
+  return { value, size }
+}
+
+function writeContainer (value, buffer, offset, typeArgs, context) {
+  Object.defineProperty(value, '..', {
+    enumerable: false,
+    configurable: true,
+    value: context
+  })
+  for (const { type, name, anon } of typeArgs) {
+    offset = tryDoc(() => this.write(anon ? value : value[name], buffer, offset, type, value), name || 'unknown')
+  }
+  return offset
+}
+
+function sizeOfContainer (value, typeArgs, context) {
+  Object.defineProperty(value, '..', {
+    enumerable: false,
+    configurable: true,
+    value: context
+  })
+  let size = 0
+  for (const { type, name, anon } of typeArgs) {
+    size += tryDoc(() => this.sizeOf(anon ? value : value[name], type, value), name || 'unknown')
+  }
+  return size
+}
+
+module.exports = {
+  'array': [readArray, writeArray, sizeOfArray, require('../../ProtoDef/schemas/structures.json')['array']],
+  'count': [readCount, writeCount, sizeOfCount, require('../../ProtoDef/schemas/structures.json')['count']],
+  'container': [readContainer, writeContainer, sizeOfContainer, require('../../ProtoDef/schemas/structures.json')['container']]
 }

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ const ProtoDef = require('./interpreter')
 const Compiler = require('./compiler')
 const utils = require('./utils')
 const types = require('./datatypes/interpreter')
+const { createEncoding } = utils
 
 module.exports = {
   ProtoDef,
@@ -10,6 +11,7 @@ module.exports = {
   Serializer,
   Parser,
   FullPacketParser,
+  createEncoding,
   utils,
   types
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,15 @@
-const ProtoDef = require('./protodef')
-const proto = new ProtoDef()
+const { Serializer, Parser, FullPacketParser } = require('./serializer')
+const ProtoDef = require('./interpreter')
+const Compiler = require('./compiler')
+const utils = require('./utils')
+const types = require('./datatypes/interpreter')
 
 module.exports = {
-  ProtoDef: ProtoDef,
-  Serializer: require('./serializer').Serializer,
-  Parser: require('./serializer').Parser,
-  FullPacketParser: require('./serializer').FullPacketParser,
-  Compiler: require('./compiler'),
-  types: proto.types,
-  utils: require('./utils')
+  ProtoDef,
+  Compiler,
+  Serializer,
+  Parser,
+  FullPacketParser,
+  utils,
+  types
 }

--- a/src/interpreter.js
+++ b/src/interpreter.js
@@ -5,9 +5,6 @@ const clonedeep = require('lodash.clonedeep')
 const Validator = require('protodef-validator')
 const defaultDatatypes = require('./datatypes/interpreter')
 
-// FIXME: Increases performance but introduces unexpected bugs in future
-const DATATYPE_NOCOPY = false
-
 class ProtoDef {
   constructor (validation = true) {
     this.validator = validation ? new Validator() : null
@@ -134,7 +131,7 @@ function findArgs (acc, v, k) {
 
 function produceArgsObject (defaultTypeArgs, argPos, typeArgs) {
   if (typeArgs === undefined) return defaultTypeArgs
-  const args = DATATYPE_NOCOPY ? defaultTypeArgs : clonedeep(defaultTypeArgs)
+  const args = clonedeep(defaultTypeArgs)
   for (const { path, val } of argPos) {
     // Set field
     const c = path.split('.').reverse()

--- a/src/interpreter.js
+++ b/src/interpreter.js
@@ -4,9 +4,6 @@ const get = require('lodash.get')
 const Validator = require('protodef-validator')
 const defaultDatatypes = require('./datatypes/interpreter')
 
-// FIXME: Increases performance but introduces unexpected bugs in future
-const DATATYPE_NOCOPY = true
-
 class ProtoDef {
   constructor (validation = true) {
     this.validator = validation ? new Validator() : null
@@ -132,7 +129,7 @@ function findArgs (acc, v, k) {
 
 function extendType (functions, defaultTypeArgs) {
   const argPos = reduce(defaultTypeArgs, findArgs, [])
-  const produceArgs = !DATATYPE_NOCOPY && typeof defaultTypeArgs === 'object'
+  const produceArgs = typeof defaultTypeArgs === 'object'
     ? function produceArgsObject (typeArgs) {
       const args = Object.assign(defaultTypeArgs.constructor(), defaultTypeArgs)
       argPos.forEach(({ path, val }) => {
@@ -146,7 +143,7 @@ function extendType (functions, defaultTypeArgs) {
       })
       return args
     }
-    : function produceArgsPrimitive () { return defaultTypeArgs }
+    : function produceArgsPrimitive (typeArgs = defaultTypeArgs) { return typeArgs }
   function read (buffer, offset, typeArgs, context) {
     return functions[0].call(this, buffer, offset, produceArgs(typeArgs), context)
   }

--- a/src/interpreter.js
+++ b/src/interpreter.js
@@ -131,6 +131,7 @@ function findArgs (acc, v, k) {
 }
 
 function constructProduceArgs (defaultTypeArgs) {
+  const argPos = reduce(defaultTypeArgs, findArgs, [])
   const json = JSON.stringify(defaultTypeArgs)
   if (defaultTypeArgs !== 'object') return () => defaultTypeArgs
   return function produceArgsObject (typeArgs) {
@@ -150,7 +151,6 @@ function constructProduceArgs (defaultTypeArgs) {
 }
 
 function extendType ([ _read, _write, _sizeOf ], defaultTypeArgs) {
-  const argPos = reduce(defaultTypeArgs, findArgs, [])
   const produceArgs = constructProduceArgs(defaultTypeArgs)
   function read (buffer, offset, typeArgs, context) {
     return _read.call(this, buffer, offset, produceArgs(typeArgs), context)

--- a/src/interpreter.js
+++ b/src/interpreter.js
@@ -5,7 +5,7 @@ const Validator = require('protodef-validator')
 const defaultDatatypes = require('./datatypes/interpreter')
 
 // FIXME: Increases performance but introduces unexpected bugs in future
-const DATATYPE_NOCOPY = true
+const DATATYPE_NOCOPY = false
 
 class ProtoDef {
   constructor (validation = true) {

--- a/src/interpreter.js
+++ b/src/interpreter.js
@@ -64,23 +64,21 @@ class ProtoDef {
   read (buffer, cursor, _fieldInfo, rootNodes) {
     const { type, typeArgs } = getFieldInfo(_fieldInfo)
     const typeFunctions = this.types[type]
-    if (!typeFunctions) { throw new Error('missing data type: ' + type) }
+    if (!typeFunctions) { throw new Error(`missing data type: ${type}`) }
     return typeFunctions[0].call(this, buffer, cursor, typeArgs, rootNodes)
   }
 
   write (value, buffer, offset, _fieldInfo, rootNode) {
     const { type, typeArgs } = getFieldInfo(_fieldInfo)
     const typeFunctions = this.types[type]
-    if (!typeFunctions) { throw new Error('missing data type: ' + type) }
+    if (!typeFunctions) { throw new Error(`missing data type: ${type}`) }
     return typeFunctions[1].call(this, value, buffer, offset, typeArgs, rootNode)
   }
 
   sizeOf (value, _fieldInfo, rootNode) {
     const { type, typeArgs } = getFieldInfo(_fieldInfo)
     const typeFunctions = this.types[type]
-    if (!typeFunctions) {
-      throw new Error('missing data type: ' + type)
-    }
+    if (!typeFunctions) { throw new Error(`missing data type: ${type}`) }
     if (typeof typeFunctions[2] === 'function') {
       return typeFunctions[2].call(this, value, typeArgs, rootNode)
     } else {

--- a/src/interpreter.js
+++ b/src/interpreter.js
@@ -4,6 +4,9 @@ const get = require('lodash.get')
 const Validator = require('protodef-validator')
 const defaultDatatypes = require('./datatypes/interpreter')
 
+// FIXME: Increases performance but introduces unexpected bugs in future
+const DATATYPE_NOCOPY = true
+
 class ProtoDef {
   constructor (validation = true) {
     this.validator = validation ? new Validator() : null
@@ -129,7 +132,7 @@ function findArgs (acc, v, k) {
 
 function extendType (functions, defaultTypeArgs) {
   const argPos = reduce(defaultTypeArgs, findArgs, [])
-  const produceArgs = typeof defaultTypeArgs === 'object'
+  const produceArgs = !DATATYPE_NOCOPY && typeof defaultTypeArgs === 'object'
     ? function produceArgsObject (typeArgs) {
       const args = Object.assign(defaultTypeArgs.constructor(), defaultTypeArgs)
       argPos.forEach(({ path, val }) => {
@@ -143,7 +146,7 @@ function extendType (functions, defaultTypeArgs) {
       })
       return args
     }
-    : function produceArgsPrimitive (typeArgs = defaultTypeArgs) { return typeArgs }
+    : function produceArgsPrimitive () { return defaultTypeArgs }
   function read (buffer, offset, typeArgs, context) {
     return functions[0].call(this, buffer, offset, produceArgs(typeArgs), context)
   }

--- a/src/protodef.js
+++ b/src/protodef.js
@@ -146,16 +146,14 @@ class ProtoDef {
   }
 
   parsePacketBuffer (type, buffer) {
-    const { value, size } = tryCatch(() => this.read(buffer, 0, type, {}),
+    const { value: data, size } = tryCatch(() => this.read(buffer, 0, type, {}),
       (e) => {
         e.message = `Read error for ${e.field} : ${e.message}`
         throw e
       })
     return {
-      data: value,
-      metadata: {
-        size: size
-      },
+      data,
+      metadata: { size },
       buffer: buffer.slice(0, size)
     }
   }

--- a/src/serializer.js
+++ b/src/serializer.js
@@ -1,4 +1,5 @@
 const Transform = require('readable-stream').Transform
+const PROTODEF_LOUD = true // TODO: Add environment variable for this
 
 class Serializer extends Transform {
   constructor (proto, mainType) {
@@ -13,7 +14,7 @@ class Serializer extends Transform {
   }
 
   _transform (chunk, enc, cb) {
-    let buf
+    let buf // DO NOT REMOVE THIS WORKAROUND!
     try {
       buf = this.createPacketBuffer(chunk)
     } catch (e) {
@@ -39,7 +40,7 @@ class Parser extends Transform {
   _transform (chunk, enc, cb) {
     this.queue = Buffer.concat([this.queue, chunk])
     while (true) {
-      let packet
+      let packet // DO NOT REMOVE THIS WORKAROUND!
       try {
         packet = this.parsePacketBuffer(this.queue)
       } catch (e) {
@@ -71,7 +72,7 @@ class FullPacketParser extends Transform {
     let packet
     try {
       packet = this.parsePacketBuffer(chunk)
-      if (packet.metadata.size !== chunk.length) {
+      if (packet.metadata.size !== chunk.length && PROTODEF_LOUD) {
         console.log('Chunk size is ' + chunk.length + ' but only ' + packet.metadata.size + ' was read ; partial packet : ' +
           JSON.stringify(packet.data) + '; buffer :' + chunk.toString('hex'))
       }

--- a/src/serializer.js
+++ b/src/serializer.js
@@ -83,8 +83,4 @@ class FullPacketParser extends Transform {
   }
 }
 
-module.exports = {
-  Serializer: Serializer,
-  Parser: Parser,
-  FullPacketParser: FullPacketParser
-}
+module.exports = { Serializer, Parser, FullPacketParser }

--- a/src/serializer.js
+++ b/src/serializer.js
@@ -73,7 +73,7 @@ class FullPacketParser extends Transform {
     try {
       packet = this.parsePacketBuffer(chunk)
       if (packet.metadata.size !== chunk.length && !this.noErrorLogging) {
-        console.log(`Chunk size is ${chunk.length} but only ${packet.metadata.size} was read ; partial packet : ${JSON.stringify(packet.data)}; buffer : ${chunk.toString('hex')}'`)
+        console.log(`Chunk size is ${chunk.length} but only ${packet.metadata.size} was read ; partial packet : ${JSON.stringify(packet.data)}; buffer : ${chunk.toString('hex')}`)
       }
     } catch (e) {
       if (e.partialReadError) {

--- a/src/serializer.js
+++ b/src/serializer.js
@@ -73,8 +73,7 @@ class FullPacketParser extends Transform {
     try {
       packet = this.parsePacketBuffer(chunk)
       if (packet.metadata.size !== chunk.length && !this.noErrorLogging) {
-        console.log('Chunk size is ' + chunk.length + ' but only ' + packet.metadata.size + ' was read ; partial packet : ' +
-          JSON.stringify(packet.data) + '; buffer :' + chunk.toString('hex'))
+        console.log(`Chunk size is ${chunk.length} but only ${packet.metadata.size} was read ; partial packet : ${JSON.stringify(packet.data)}; buffer : ${chunk.toString('hex')}'`)
       }
     } catch (e) {
       if (e.partialReadError) {
@@ -82,9 +81,8 @@ class FullPacketParser extends Transform {
           console.log(e.stack)
         }
         return cb()
-      } else {
-        return cb(e)
       }
+      return cb(e)
     }
     this.push(packet)
     cb()

--- a/src/utils.js
+++ b/src/utils.js
@@ -76,7 +76,7 @@ function getFieldInfo (fieldInfo) {
     case typeof fieldInfo.type === 'string':
       return fieldInfo
     default:
-      throw new Error(fieldInfo + ' is not a fieldinfo')
+      throw new Error(`${fieldInfo} is not a fieldinfo`)
   }
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -100,6 +100,28 @@ function calcCount (len, { count, countType }, rootNode) {
   return 0
 }
 
+function createEncoding (inst, type) {
+  const encoding = {}
+  encoding.encode = (obj, buffer, offset) => {
+    if (buffer) {
+      encoding.encode.bytes = inst.write(obj, buffer, offset, type)
+    } else {
+      buffer = inst.createPacketBuffer(type, obj)
+      encoding.encode.bytes = buffer.length
+    }
+    return buffer
+  }
+  encoding.decode = (buffer, start, end) => {
+    const { value, size } = inst.read(buffer.slice(start, end), 0, type)
+    encoding.decode.bytes = size
+    return value
+  }
+  encoding.encodingLength = (obj) => {
+    return inst.sizeOf(obj, type)
+  }
+  return encoding
+}
+
 module.exports = {
   Enum,
   PartialReadError,
@@ -110,5 +132,6 @@ module.exports = {
   isFieldInfo,
   getCount,
   sendCount,
-  calcCount
+  calcCount,
+  createEncoding
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,8 +1,8 @@
 const Enum = Object.freeze({
   CompilerTypeKind: {
-    NATIVE: 'native',
-    CONTEXT: 'context',
-    PARAMETRIZABLE: 'parametrizable'
+    NATIVE: 0,
+    CONTEXT: 1,
+    PARAMETRIZABLE: 2
   },
   ParentSymbol: typeof Symbol !== 'undefined' ? Symbol('ProtoDefContext') : '..'
 })

--- a/src/utils.js
+++ b/src/utils.js
@@ -85,6 +85,14 @@ class PartialReadError extends ExtendableError {
   }
 }
 
+const Enum = Object.freeze({
+  CompilerTypeKind: {
+    NATIVE: 'native',
+    CONTEXT: 'context',
+    PARAMETRIZABLE: 'parametrizable'
+  }
+})
+
 module.exports = {
   getField,
   getFieldInfo,
@@ -93,5 +101,6 @@ module.exports = {
   calcCount,
   tryCatch,
   tryDoc,
-  PartialReadError
+  PartialReadError,
+  Enum
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -92,7 +92,7 @@ function getCount (buffer, offset, { count, countType }, rootNode) {
     return new CountResult(count, 0)
   }
   if (countType !== undefined) {
-    const { size, value } = tryDoc(() => this.read(buffer, offset, getFieldInfo(countType), rootNode), '$count')
+    const { size, value } = tryDoc(this.read.bind(this, buffer, offset, getFieldInfo(countType), rootNode), '$count')
     return new CountResult(value, size)
   }
   throw new Error('Broken schema, neither count nor countType defined')
@@ -113,7 +113,7 @@ function sendCount (len, buffer, offset, { count, countType }, rootNode) {
 
 function calcCount (len, { count, countType }, rootNode) {
   if (count === undefined && countType !== undefined) {
-    return tryDoc(() => this.sizeOf(len, getFieldInfo(countType), rootNode), '$count')
+    return tryDoc(this.sizeOf.bind(this, len, getFieldInfo(countType), rootNode), '$count')
   }
   return 0
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -15,10 +15,7 @@ class Result {
     this.value = value
     this.size = size
   }
-}
-
-class CountResult extends Result {
-  // This line will be inlined
+  // This getter will be inlined
   get count () { return this.value }
 }
 
@@ -89,11 +86,11 @@ function isFieldInfo (type) {
 function getCount (buffer, offset, { count, countType }, rootNode) {
   if (count !== undefined) {
     count = typeof count === 'number' ? count : getField(count, rootNode)
-    return new CountResult(count, 0)
+    return new Result(count, 0)
   }
   if (countType !== undefined) {
     const { size, value } = tryDoc(this.read.bind(this, buffer, offset, getFieldInfo(countType), rootNode), '$count')
-    return new CountResult(value, size)
+    return new Result(value, size)
   }
   throw new Error('Broken schema, neither count nor countType defined')
 }


### PR DESCRIPTION
Closes #69 and #75

Benchmark results by @Karang (benchmark_all_types):
```markdown
**ProtoDef-io:master**:
read x 26,817 ops/sec ±1.43% (92 runs sampled)
  ✓ reads (5617ms)
write x 16,188 ops/sec ±0.46% (96 runs sampled)
  ✓ writes (5788ms)
read (compiled) x 104,248 ops/sec ±1.56% (87 runs sampled)
  ✓ reads (compiled) (5474ms)
write (compiled) x 79,582 ops/sec ±0.39% (95 runs sampled)
  ✓ writes (compiled) (5616ms)
**Saiv46:master**:
read x 67,847 ops/sec ±0.45% (95 runs sampled)
  ✓ reads (5676ms)
write x 40,270 ops/sec ±0.38% (95 runs sampled)
  ✓ writes (5558ms)
read (compiled) x 102,333 ops/sec ±1.02% (93 runs sampled)
  ✓ reads (compiled) (5524ms)
write (compiled) x 77,432 ops/sec ±1.04% (86 runs sampled)
  ✓ writes (compiled) (5614ms)
```