### PR TITLE
Fix undefined varint for SizeOf and Write

### DIFF
--- a/src/compiler.js
+++ b/src/compiler.js
@@ -220,7 +220,9 @@ class Compiler {
       if (!functions[type]) {
         if (this.types[type] !== 'native') {
           functions[type] = this.compileType(this.types[type])
-          if (functions[type].startsWith('ctx')) { functions[type] = this.wrapCode('return ' + this.callType(functions[type].split('.')[1])) }
+          if (functions[type].startsWith('ctx')) {
+            functions[type] = 'function () { return ' + functions[type] + '(...arguments) }'
+          }
           if (!isNaN(functions[type])) { functions[type] = this.wrapCode('  return ' + functions[type]) }
         } else {
           functions[type] = `native.${type}`


### PR DESCRIPTION
callType() have a different order of parameter depending on the type of compiler (Read, Sizeof, Write) Ultimately we want to change that so the type is always the first parameter and the other parameters have default values, but that require many changes in many projects (protodef, node-minecraft-protocol, prismarine-nbt). This is a simpler fix.