### PR TITLE
compiler: Don't read abnormally large arrays

### DIFF
--- a/src/datatypes/compiler-structures.js
+++ b/src/datatypes/compiler-structures.js
@@ -10,6 +10,7 @@ module.exports = {
       } else {
         throw new Error('Array must contain either count or countType')
       }
+      code += 'if (count > 0xffffff) throw new Error("array size is abnormally large, not reading: " + count)\n'
       code += 'const data = []\n'
       code += 'let size = countSize\n'
       code += 'for (let i = 0; i < count; i++) {\n'


### PR DESCRIPTION
Avoid OOM crashes when parsing arrays with abnormally large sizes

I'm not sure what the best way to deal with the OOM crashes is, but this quick fix seems to work for now.