### PR TITLE
BigInt writing support, and support reading from buffer offset

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -58,9 +58,9 @@ Returns a buffer of the `packet`.
 
 Create a parser of `mainType` defined in `proto`. This is a Transform stream.
 
-### Parser.parsePacketBuffer(buffer, offset = 0)
+### Parser.parsePacketBuffer(buffer)
 
-Returns a parsed packet of `buffer` starting at `offset`.
+Returns a parsed packet of `buffer`.
 
 ## types
 

--- a/doc/api.md
+++ b/doc/api.md
@@ -42,9 +42,9 @@ Size of the packet `value` defined by `_fieldInfo` with context `rootNode`
 
 Returns a buffer of the `packet` for `type`.
 
-### ProtoDef.parsePacketBuffer(type,buffer)
+### ProtoDef.parsePacketBuffer(type,buffer,offset = 0)
 
-Returns a parsed packet of `buffer` for `type`.
+Returns a parsed packet of `buffer` for `type` starting at `offset`.
 
 ## Serializer(proto,mainType)
 
@@ -58,9 +58,9 @@ Returns a buffer of the `packet`.
 
 Create a parser of `mainType` defined in `proto`. This is a Transform stream.
 
-### Parser.parsePacketBuffer(buffer)
+### Parser.parsePacketBuffer(buffer, offset = 0)
 
-Returns a parsed packet of `buffer`.
+Returns a parsed packet of `buffer` starting at `offset`.
 
 ## types
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "readable-stream": "^3.0.3"
   },
   "engines": {
-    "node": ">=6"
+    "node": ">=10.4"
   },
   "bugs": {
     "url": "https://github.com/ProtoDef-io/node-protodef/issues"
@@ -30,6 +30,11 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/ProtoDef-io/node-protodef.git"
+  },
+  "standard": {
+    "ignore": [
+      "src/datatypes/numeric.js"
+    ]
   },
   "devDependencies": {
     "benchmark": "^2.1.4",

--- a/src/compiler.js
+++ b/src/compiler.js
@@ -95,8 +95,8 @@ class CompiledProtodef {
     return buffer
   }
 
-  parsePacketBuffer (type, buffer) {
-    const { value, size } = tryCatch(() => this.read(buffer, 0, type),
+  parsePacketBuffer (type, buffer, offset = 0) {
+    const { value, size } = tryCatch(() => this.read(buffer, offset, type),
       (e) => {
         e.message = `Read error for ${e.field} : ${e.message}`
         throw e

--- a/src/datatypes/numeric.js
+++ b/src/datatypes/numeric.js
@@ -14,7 +14,7 @@ function readI64 (buffer, offset) {
 }
 
 function writeI64 (value, buffer, offset) {
-  if (value instanceof BigInt) {
+  if (typeof value === 'bigint') {
     buffer.writeBigInt64BE(value, offset)
   } else {
     buffer.writeInt32BE(value[0], offset)
@@ -33,7 +33,7 @@ function readLI64 (buffer, offset) {
 }
 
 function writeLI64 (value, buffer, offset) {
-  if (value instanceof BigInt) {
+  if (typeof value === 'bigint') {
     buffer.writeBigInt64LE(value, offset)
   } else {
     buffer.writeInt32LE(value[0], offset + 4)
@@ -52,7 +52,7 @@ function readU64 (buffer, offset) {
 }
 
 function writeU64 (value, buffer, offset) {
-  if (value instanceof BigInt) {
+  if (typeof value === 'bigint') {
     buffer.writeBigUInt64BE(value, offset)
   } else {
     buffer.writeUInt32BE(value[0], offset)
@@ -71,7 +71,7 @@ function readLU64 (buffer, offset) {
 }
 
 function writeLU64 (value, buffer, offset) {
-  if (value instanceof BigInt) {
+  if (typeof value === 'bigint') {
     buffer.writeBigUInt64LE(value, offset)
   } else {
     buffer.writeUInt32LE(value[0], offset + 4)
@@ -90,7 +90,7 @@ function generateFunctions (bufferReader, bufferWriter, size, schema) {
     }
   }
   const writer = (value, buffer, offset) => {
-    if (value instanceof BigInt) value = Number(value)
+    if (typeof value === 'bigint') value = Number(value)
     buffer[bufferWriter](value, offset)
     return offset + size
   }

--- a/src/datatypes/numeric.js
+++ b/src/datatypes/numeric.js
@@ -14,7 +14,7 @@ function readI64 (buffer, offset) {
 }
 
 function writeI64 (value, buffer, offset) {
-  if (value instanceof BigIntExtended || value instanceof BigInt) {
+  if (value instanceof BigInt) {
     buffer.writeBigInt64BE(value, offset)
   } else {
     buffer.writeInt32BE(value[0], offset)
@@ -33,7 +33,7 @@ function readLI64 (buffer, offset) {
 }
 
 function writeLI64 (value, buffer, offset) {
-  if (value instanceof BigIntExtended || value instanceof BigInt) {
+  if (value instanceof BigInt) {
     buffer.writeBigInt64LE(value, offset)
   } else {
     buffer.writeInt32LE(value[0], offset + 4)
@@ -52,7 +52,7 @@ function readU64 (buffer, offset) {
 }
 
 function writeU64 (value, buffer, offset) {
-  if (value instanceof BigIntExtended || value instanceof BigInt) {
+  if (value instanceof BigInt) {
     buffer.writeBigUInt64BE(value, offset)
   } else {
     buffer.writeUInt32BE(value[0], offset)
@@ -71,7 +71,7 @@ function readLU64 (buffer, offset) {
 }
 
 function writeLU64 (value, buffer, offset) {
-  if (value instanceof BigIntExtended || value instanceof BigInt) {
+  if (value instanceof BigInt) {
     buffer.writeBigUInt64LE(value, offset)
   } else {
     buffer.writeUInt32LE(value[0], offset + 4)
@@ -90,7 +90,7 @@ function generateFunctions (bufferReader, bufferWriter, size, schema) {
     }
   }
   const writer = (value, buffer, offset) => {
-    if (value instanceof BigIntExtended || value instanceof BigInt) value = Number(value)
+    if (value instanceof BigInt) value = Number(value)
     buffer[bufferWriter](value, offset)
     return offset + size
   }

--- a/src/datatypes/numeric.js
+++ b/src/datatypes/numeric.js
@@ -6,7 +6,6 @@ class BigIntExtended extends Array {
 
 function readI64 (buffer, offset) {
   if (offset + 8 > buffer.length) { throw new PartialReadError() }
-  const val = buffer.readBigInt64BE(offset)
   return {
     value: new BigIntExtended(buffer.readInt32BE(offset), buffer.readInt32BE(offset + 4)),
     size: 8
@@ -25,7 +24,6 @@ function writeI64 (value, buffer, offset) {
 
 function readLI64 (buffer, offset) {
   if (offset + 8 > buffer.length) { throw new PartialReadError() }
-  const val = buffer.readBigInt64LE(offset)
   return {
     value: new BigIntExtended(buffer.readInt32LE(offset + 4), buffer.readInt32LE(offset)),
     size: 8
@@ -44,7 +42,6 @@ function writeLI64 (value, buffer, offset) {
 
 function readU64 (buffer, offset) {
   if (offset + 8 > buffer.length) { throw new PartialReadError() }
-  const val = buffer.readBigUInt64BE(offset)
   return {
     value: new BigIntExtended(buffer.readUInt32BE(offset), buffer.readUInt32BE(offset + 4)),
     size: 8
@@ -63,7 +60,6 @@ function writeU64 (value, buffer, offset) {
 
 function readLU64 (buffer, offset) {
   if (offset + 8 > buffer.length) { throw new PartialReadError() }
-  const val = buffer.readBigUInt64LE(offset)
   return {
     value: new BigIntExtended(buffer.readUInt32LE(offset + 4), buffer.readUInt32LE(offset)),
     size: 8
@@ -90,7 +86,6 @@ function generateFunctions (bufferReader, bufferWriter, size, schema) {
     }
   }
   const writer = (value, buffer, offset) => {
-    if (typeof value === 'bigint') value = Number(value)
     buffer[bufferWriter](value, offset)
     return offset + size
   }

--- a/src/datatypes/numeric.js
+++ b/src/datatypes/numeric.js
@@ -14,7 +14,7 @@ function readI64 (buffer, offset) {
 }
 
 function writeI64 (value, buffer, offset) {
-  if (typeof value.valueOf() === 'bigint') {
+  if (value instanceof BigIntExtended || value instanceof BigInt) {
     buffer.writeBigInt64BE(value, offset)
   } else {
     buffer.writeInt32BE(value[0], offset)
@@ -33,7 +33,7 @@ function readLI64 (buffer, offset) {
 }
 
 function writeLI64 (value, buffer, offset) {
-  if (typeof value.valueOf() === 'bigint') {
+  if (value instanceof BigIntExtended || value instanceof BigInt) {
     buffer.writeBigInt64LE(value, offset)
   } else {
     buffer.writeInt32LE(value[0], offset + 4)
@@ -52,7 +52,7 @@ function readU64 (buffer, offset) {
 }
 
 function writeU64 (value, buffer, offset) {
-  if (typeof value.valueOf() === 'bigint') {
+  if (value instanceof BigIntExtended || value instanceof BigInt) {
     buffer.writeBigUInt64BE(value, offset)
   } else {
     buffer.writeUInt32BE(value[0], offset)
@@ -71,7 +71,7 @@ function readLU64 (buffer, offset) {
 }
 
 function writeLU64 (value, buffer, offset) {
-  if (typeof value.valueOf() === 'bigint') {
+  if (value instanceof BigIntExtended || value instanceof BigInt) {
     buffer.writeBigUInt64LE(value, offset)
   } else {
     buffer.writeUInt32LE(value[0], offset + 4)
@@ -90,7 +90,7 @@ function generateFunctions (bufferReader, bufferWriter, size, schema) {
     }
   }
   const writer = (value, buffer, offset) => {
-    if (typeof value.valueOf() === 'bigint') value = Number(value)
+    if (value instanceof BigIntExtended || value instanceof BigInt) value = Number(value)
     buffer[bufferWriter](value, offset)
     return offset + size
   }

--- a/src/datatypes/numeric.js
+++ b/src/datatypes/numeric.js
@@ -1,10 +1,10 @@
 const { PartialReadError } = require('../utils')
 
 class BigIntExtended extends Array {
-  constructor (arg, isLE) {
+  constructor (arg) {
     if (typeof arg === 'number') arg = BigInt(arg)
-    const upper = BigInt.asIntN(32, (arg >> 32n) & 0xFFFFFFFFn)
-    const lower = BigInt.asIntN(32, arg & 0xFFFFFFFFn)
+    const upper = BigInt.asIntN(32, arg >> 32n)
+    const lower = BigInt.asIntN(32, arg)
     super(Number(upper), Number(lower))
     this.valueOf = () => arg
   }
@@ -14,7 +14,7 @@ function readI64 (buffer, offset) {
   if (offset + 8 > buffer.length) { throw new PartialReadError() }
   const val = buffer.readBigInt64BE(offset)
   return {
-    value: new BigIntExtended(val, false),
+    value: new BigIntExtended(val),
     size: 8
   }
 }
@@ -33,7 +33,7 @@ function readLI64 (buffer, offset) {
   if (offset + 8 > buffer.length) { throw new PartialReadError() }
   const val = buffer.readBigInt64LE(offset)
   return {
-    value: new BigIntExtended(val, true),
+    value: new BigIntExtended(val),
     size: 8
   }
 }
@@ -52,7 +52,7 @@ function readU64 (buffer, offset) {
   if (offset + 8 > buffer.length) { throw new PartialReadError() }
   const val = buffer.readBigUInt64BE(offset)
   return {
-    value: new BigIntExtended(val, false),
+    value: new BigIntExtended(val),
     size: 8
   }
 }
@@ -71,7 +71,7 @@ function readLU64 (buffer, offset) {
   if (offset + 8 > buffer.length) { throw new PartialReadError() }
   const val = buffer.readBigUInt64LE(offset)
   return {
-    value: new BigIntExtended(val, true),
+    value: new BigIntExtended(val),
     size: 8
   }
 }

--- a/src/datatypes/numeric.js
+++ b/src/datatypes/numeric.js
@@ -6,8 +6,8 @@ class BigIntExtended extends Array {
     const upper = BigInt.asIntN(32, arg >> 32n)
     const lower = BigInt.asIntN(32, arg)
     super(Number(upper), Number(lower))
-    this.valueOf = () => arg
   }
+  valueOf () { return BigInt.asIntN(64, BigInt(this[0]) << 32n) | BigInt.asUintN(32, BigInt(this[1])) }
 }
 
 function readI64 (buffer, offset) {

--- a/src/datatypes/numeric.js
+++ b/src/datatypes/numeric.js
@@ -9,8 +9,12 @@ function readI64 (buffer, offset) {
 }
 
 function writeI64 (value, buffer, offset) {
-  buffer.writeInt32BE(value[0], offset)
-  buffer.writeInt32BE(value[1], offset + 4)
+  if (typeof value == 'bigint') {
+    buffer.writeBigInt64BE(value, offset)
+  } else {
+    buffer.writeInt32BE(value[0], offset)
+    buffer.writeInt32BE(value[1], offset + 4)
+  }
   return offset + 8
 }
 
@@ -23,8 +27,12 @@ function readLI64 (buffer, offset) {
 }
 
 function writeLI64 (value, buffer, offset) {
-  buffer.writeInt32LE(value[0], offset + 4)
-  buffer.writeInt32LE(value[1], offset)
+  if (typeof value == 'bigint') {
+    buffer.writeBigInt64LE(value, offset)
+  } else {
+    buffer.writeInt32LE(value[0], offset + 4)
+    buffer.writeInt32LE(value[1], offset)
+  }
   return offset + 8
 }
 
@@ -37,8 +45,12 @@ function readU64 (buffer, offset) {
 }
 
 function writeU64 (value, buffer, offset) {
-  buffer.writeUInt32BE(value[0], offset)
-  buffer.writeUInt32BE(value[1], offset + 4)
+  if (typeof value == 'bigint') {
+    buffer.writeBigUInt64BE(value, offset)
+  } else {
+    buffer.writeUInt32BE(value[0], offset)
+    buffer.writeUInt32BE(value[1], offset + 4)
+  }
   return offset + 8
 }
 
@@ -51,8 +63,12 @@ function readLU64 (buffer, offset) {
 }
 
 function writeLU64 (value, buffer, offset) {
-  buffer.writeUInt32LE(value[0], offset + 4)
-  buffer.writeUInt32LE(value[1], offset)
+  if (typeof value == 'bigint') {
+    buffer.writeBigUInt64LE(value, offset)
+  } else {
+    buffer.writeUInt32LE(value[0], offset + 4)
+    buffer.writeUInt32LE(value[1], offset)
+  }
   return offset + 8
 }
 
@@ -66,6 +82,7 @@ function generateFunctions (bufferReader, bufferWriter, size, schema) {
     }
   }
   const writer = (value, buffer, offset) => {
+    if (typeof value == 'bigint') value = Number(value)
     buffer[bufferWriter](value, offset)
     return offset + size
   }

--- a/src/datatypes/numeric.js
+++ b/src/datatypes/numeric.js
@@ -9,7 +9,7 @@ function readI64 (buffer, offset) {
 }
 
 function writeI64 (value, buffer, offset) {
-  if (typeof value === 'bigint') {
+  if (typeof value === 'bigint') { // eslint-disable-line
     buffer.writeBigInt64BE(value, offset)
   } else {
     buffer.writeInt32BE(value[0], offset)
@@ -27,7 +27,7 @@ function readLI64 (buffer, offset) {
 }
 
 function writeLI64 (value, buffer, offset) {
-  if (typeof value === 'bigint') {
+  if (typeof value === 'bigint') { // eslint-disable-line
     buffer.writeBigInt64LE(value, offset)
   } else {
     buffer.writeInt32LE(value[0], offset + 4)
@@ -45,7 +45,7 @@ function readU64 (buffer, offset) {
 }
 
 function writeU64 (value, buffer, offset) {
-  if (typeof value === 'bigint') {
+  if (typeof value === 'bigint') { // eslint-disable-line
     buffer.writeBigUInt64BE(value, offset)
   } else {
     buffer.writeUInt32BE(value[0], offset)
@@ -63,7 +63,7 @@ function readLU64 (buffer, offset) {
 }
 
 function writeLU64 (value, buffer, offset) {
-  if (typeof value === 'bigint') {
+  if (typeof value === 'bigint') { // eslint-disable-line
     buffer.writeBigUInt64LE(value, offset)
   } else {
     buffer.writeUInt32LE(value[0], offset + 4)
@@ -82,7 +82,7 @@ function generateFunctions (bufferReader, bufferWriter, size, schema) {
     }
   }
   const writer = (value, buffer, offset) => {
-    if (typeof value === 'bigint') value = Number(value)
+    if (typeof value === 'bigint') value = Number(value) // eslint-disable-line
     buffer[bufferWriter](value, offset)
     return offset + size
   }

--- a/src/datatypes/numeric.js
+++ b/src/datatypes/numeric.js
@@ -1,12 +1,6 @@
 const { PartialReadError } = require('../utils')
 
 class BigIntExtended extends Array {
-  constructor (arg) {
-    if (typeof arg === 'number') arg = BigInt(arg)
-    const upper = BigInt.asIntN(32, arg >> 32n)
-    const lower = BigInt.asIntN(32, arg)
-    super(Number(upper), Number(lower))
-  }
   valueOf () { return BigInt.asIntN(64, BigInt(this[0]) << 32n) | BigInt.asUintN(32, BigInt(this[1])) }
 }
 
@@ -14,7 +8,7 @@ function readI64 (buffer, offset) {
   if (offset + 8 > buffer.length) { throw new PartialReadError() }
   const val = buffer.readBigInt64BE(offset)
   return {
-    value: new BigIntExtended(val),
+    value: new BigIntExtended(buffer.readInt32BE(offset), buffer.readInt32BE(offset + 4)),
     size: 8
   }
 }
@@ -33,7 +27,7 @@ function readLI64 (buffer, offset) {
   if (offset + 8 > buffer.length) { throw new PartialReadError() }
   const val = buffer.readBigInt64LE(offset)
   return {
-    value: new BigIntExtended(val),
+    value: new BigIntExtended(buffer.readInt32LE(offset + 4), buffer.readInt32LE(offset)),
     size: 8
   }
 }
@@ -52,7 +46,7 @@ function readU64 (buffer, offset) {
   if (offset + 8 > buffer.length) { throw new PartialReadError() }
   const val = buffer.readBigUInt64BE(offset)
   return {
-    value: new BigIntExtended(val),
+    value: new BigIntExtended(buffer.readUInt32BE(offset), buffer.readUInt32BE(offset + 4)),
     size: 8
   }
 }
@@ -71,7 +65,7 @@ function readLU64 (buffer, offset) {
   if (offset + 8 > buffer.length) { throw new PartialReadError() }
   const val = buffer.readBigUInt64LE(offset)
   return {
-    value: new BigIntExtended(val),
+    value: new BigIntExtended(buffer.readUInt32LE(offset + 4), buffer.readUInt32LE(offset)),
     size: 8
   }
 }

--- a/src/datatypes/numeric.js
+++ b/src/datatypes/numeric.js
@@ -9,7 +9,7 @@ function readI64 (buffer, offset) {
 }
 
 function writeI64 (value, buffer, offset) {
-  if (typeof value == 'bigint') {
+  if (typeof value === 'bigint') {
     buffer.writeBigInt64BE(value, offset)
   } else {
     buffer.writeInt32BE(value[0], offset)
@@ -27,7 +27,7 @@ function readLI64 (buffer, offset) {
 }
 
 function writeLI64 (value, buffer, offset) {
-  if (typeof value == 'bigint') {
+  if (typeof value === 'bigint') {
     buffer.writeBigInt64LE(value, offset)
   } else {
     buffer.writeInt32LE(value[0], offset + 4)
@@ -45,7 +45,7 @@ function readU64 (buffer, offset) {
 }
 
 function writeU64 (value, buffer, offset) {
-  if (typeof value == 'bigint') {
+  if (typeof value === 'bigint') {
     buffer.writeBigUInt64BE(value, offset)
   } else {
     buffer.writeUInt32BE(value[0], offset)
@@ -63,7 +63,7 @@ function readLU64 (buffer, offset) {
 }
 
 function writeLU64 (value, buffer, offset) {
-  if (typeof value == 'bigint') {
+  if (typeof value === 'bigint') {
     buffer.writeBigUInt64LE(value, offset)
   } else {
     buffer.writeUInt32LE(value[0], offset + 4)
@@ -82,7 +82,7 @@ function generateFunctions (bufferReader, bufferWriter, size, schema) {
     }
   }
   const writer = (value, buffer, offset) => {
-    if (typeof value == 'bigint') value = Number(value)
+    if (typeof value === 'bigint') value = Number(value)
     buffer[bufferWriter](value, offset)
     return offset + size
   }

--- a/src/protodef.js
+++ b/src/protodef.js
@@ -145,8 +145,8 @@ class ProtoDef {
     return buffer
   }
 
-  parsePacketBuffer (type, buffer) {
-    const { value, size } = tryCatch(() => this.read(buffer, 0, type, {}),
+  parsePacketBuffer (type, buffer, offset = 0) {
+    const { value, size } = tryCatch(() => this.read(buffer, offset, type, {}),
       (e) => {
         e.message = `Read error for ${e.field} : ${e.message}`
         throw e


### PR DESCRIPTION
BigInt writing support, and support reading from buffer offset

If you're reading from a stream of data, it's easier and more efficient to increment offset position than make a new buffer slice every time. 