### PR TITLE
Expose compiler, use let instead of const, map updates

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -84,6 +84,16 @@ The `path` is an array of namespace keys which select a path of namespaces to be
 
 Compile and return a `ProtoDef` object, optionaly print the generated javascript code.
 
+## CompiledProtodef
+
+The class of which an instance is returned by compileProtoDefSync
+
+It follows the same interface as ProtoDef : read, write, sizeOf, createPacketBuffer, parsePacketBuffer
+Its constructor is CompiledProtodef(sizeOfCtx, writeCtx, readCtx). 
+sizeOfCtx, writeCtx and readCtx are the compiled version of sizeOf, write and read. They are produced by Compiler.compile
+
+It can be used directly for easier debugging/using already compiled js.
+
 ## utils
 
 Some functions that can be useful to build new datatypes reader and writer.

--- a/src/compiler.js
+++ b/src/compiler.js
@@ -418,5 +418,6 @@ module.exports = {
   ReadCompiler,
   WriteCompiler,
   SizeOfCompiler,
-  ProtoDefCompiler
+  ProtoDefCompiler,
+  CompiledProtodef
 }

--- a/src/datatypes/compiler-structures.js
+++ b/src/datatypes/compiler-structures.js
@@ -51,7 +51,7 @@ module.exports = {
           if (name === trueName) names.push(name)
           else names.push(`${name}: ${trueName}`)
         }
-        code += `const { value: ${trueName}, size: ${sizeName} } = ` + compiler.callType(type, offsetExpr) + '\n'
+        code += `let { value: ${trueName}, size: ${sizeName} } = ` + compiler.callType(type, offsetExpr) + '\n'
         offsetExpr += ` + ${sizeName}`
       }
       const sizes = offsetExpr.split(' + ')
@@ -97,7 +97,7 @@ module.exports = {
           trueName = '{' + names.join(', ') + '}'
         } else {
           trueName = compiler.getField(name)
-          code += `const ${trueName} = value.${name}\n`
+          code += `let ${trueName} = value.${name}\n`
         }
         code += 'offset = ' + compiler.callType(trueName, type) + '\n'
       }
@@ -147,7 +147,7 @@ module.exports = {
           trueName = '{' + names.join(', ') + '}'
         } else {
           trueName = compiler.getField(name)
-          code += `const ${trueName} = value.${name}\n`
+          code += `let ${trueName} = value.${name}\n`
         }
         code += 'size += ' + compiler.callType(trueName, type) + '\n'
       }

--- a/src/datatypes/compiler-utils.js
+++ b/src/datatypes/compiler-utils.js
@@ -160,8 +160,11 @@ module.exports = {
 function sanitizeMappings (json) {
   const ret = {}
   for (let key in json) {
-    const val = json[key]
+    let val = json[key]
     key = hex2dec(key)
+    if (!isNaN(val)) val = Number(val)
+    if (val === 'true') val = true
+    if (val === 'false') val = false
     ret[key] = val
   }
   return ret

--- a/src/datatypes/compiler-utils.js
+++ b/src/datatypes/compiler-utils.js
@@ -60,7 +60,7 @@ module.exports = {
     }],
     mapper: ['parametrizable', (compiler, mapper) => {
       let code = 'const { value, size } = ' + compiler.callType(mapper.type) + '\n'
-      code += 'return { value: ' + JSON.stringify(sanitizeMappings(mapper.mappings)) + '[value], size }'
+      code += 'return { value: ' + JSON.stringify(sanitizeMappings(mapper.mappings)) + '[value] || value, size }'
       return compiler.wrapCode(code)
     }]
   },
@@ -118,7 +118,7 @@ module.exports = {
     }],
     mapper: ['parametrizable', (compiler, mapper) => {
       const mappings = JSON.stringify(swapMappings(mapper.mappings))
-      const code = 'return ' + compiler.callType(`${mappings}[value]`, mapper.type)
+      const code = 'return ' + compiler.callType(`${mappings}[value] || value`, mapper.type)
       return compiler.wrapCode(code)
     }]
   },
@@ -150,7 +150,7 @@ module.exports = {
     }],
     mapper: ['parametrizable', (compiler, mapper) => {
       const mappings = JSON.stringify(swapMappings(mapper.mappings))
-      const code = 'return ' + compiler.callType(`${mappings}[value]`, mapper.type)
+      const code = 'return ' + compiler.callType(`${mappings}[value] || value`, mapper.type)
       return compiler.wrapCode(code)
     }]
   }


### PR DESCRIPTION
* Exposes CompiledProtodef for easier debugging/using already compiled js
* use let instead of const for containers, allows for variables to be modified after (used [here](https://github.com/extremeheat/pocket-minecraft-protocol/blob/new/src/datatypes/compiler-minecraft.js#L104))
* `mapper` type now returns the number if mapping fails (avoids needing to map lots of [unknown values](https://github.com/extremeheat/pocket-minecraft-protocol/blob/9e1500ec775501f824098cc4ec46dd19c8dfaee2/data/new/proto.yml#L1257))
* `sanitizeMappings` now converts strings to numbers/booleans to match the logic in switch statements https://github.com/ProtoDef-io/node-protodef/blob/master/src/datatypes/compiler-conditional.js#L13 , previously mapping numbers would work because of type coercion: `switch ("355") { case 355: ... }` == `"355" == 355`  however the same won't work for booleans : `('true' == true)` returns false.
