### PR TITLE
Allow JSON stringified buffers to be converted to Buffer when serializing

### DIFF
--- a/src/datatypes/compiler-utils.js
+++ b/src/datatypes/compiler-utils.js
@@ -78,7 +78,7 @@ module.exports = {
       return compiler.wrapCode(code)
     }],
     buffer: ['parametrizable', (compiler, buffer) => {
-      let code = ''
+      let code = 'if (!(value instanceof Buffer)) value = Buffer.from(value)\n'
       if (buffer.countType) {
         code += 'offset = ' + compiler.callType('value.length', buffer.countType) + '\n'
       } else if (buffer.count === null) {
@@ -135,7 +135,7 @@ module.exports = {
       return compiler.wrapCode(code)
     }],
     buffer: ['parametrizable', (compiler, buffer) => {
-      let code = 'let size = value.length\n'
+      let code = 'let size = value instanceof Buffer ? value.length : Buffer.from(value).length\n'
       if (buffer.countType) {
         code += 'size += ' + compiler.callType('size', buffer.countType) + '\n'
       } else if (buffer.count === null) {

--- a/src/datatypes/utils.js
+++ b/src/datatypes/utils.js
@@ -154,12 +154,14 @@ function readBuffer (buffer, offset, typeArgs, rootNode) {
 }
 
 function writeBuffer (value, buffer, offset, typeArgs, rootNode) {
+  if (!(value instanceof Buffer)) value = Buffer.from(value)
   offset = sendCount.call(this, value.length, buffer, offset, typeArgs, rootNode)
   value.copy(buffer, offset)
   return offset + value.length
 }
 
 function sizeOfBuffer (value, typeArgs, rootNode) {
+  if (!(value instanceof Buffer)) value = Buffer.from(value)
   const size = calcCount.call(this, value.length, typeArgs, rootNode)
   return size + value.length
 }


### PR DESCRIPTION
Needed for https://github.com/PrismarineJS/bedrock-protocol/pull/83, allows serializing previously JSON.stringified packets.