### PR TITLE
Show BigInt instead of BigIntExtended when using console.log

### DIFF
--- a/src/datatypes/numeric.js
+++ b/src/datatypes/numeric.js
@@ -2,6 +2,7 @@ const { PartialReadError } = require('../utils')
 
 class BigIntExtended extends Array {
   valueOf () { return BigInt.asIntN(64, BigInt(this[0]) << 32n) | BigInt.asUintN(32, BigInt(this[1])) }
+  [Symbol.for('nodejs.util.inspect.custom')] () { return this.valueOf() } 
 }
 
 function readI64 (buffer, offset) {

--- a/src/datatypes/numeric.js
+++ b/src/datatypes/numeric.js
@@ -2,7 +2,7 @@ const { PartialReadError } = require('../utils')
 
 class BigIntExtended extends Array {
   valueOf () { return BigInt.asIntN(64, BigInt(this[0]) << 32n) | BigInt.asUintN(32, BigInt(this[1])) }
-  [Symbol.for('nodejs.util.inspect.custom')] () { return this.valueOf() } 
+  [Symbol.for('nodejs.util.inspect.custom')] () { return this.valueOf() }
 }
 
 function readI64 (buffer, offset) {


### PR DESCRIPTION
  `hashedSeed: BigIntExtended(2) [ -1252218895, -971237565 ]` ->
  `hashedSeed: -5378239198134528189n`
https://nodejs.org/api/util.html#util_custom_inspection_functions_on_objects
