### PR TITLE
Just crash on failed packet buffer creation

### DIFF
--- a/src/serializer.js
+++ b/src/serializer.js
@@ -13,12 +13,7 @@ class Serializer extends Transform {
   }
 
   _transform (chunk, enc, cb) {
-    let buf
-    try {
-      buf = this.createPacketBuffer(chunk)
-    } catch (e) {
-      return cb(e)
-    }
+    let buf = this.createPacketBuffer(chunk)
     this.push(buf)
     return cb()
   }


### PR DESCRIPTION
There's no reasonable way to handle this error condition. If users want to try-catch their writes they're free to at a level higher than this, but this try-catch hides buffer creation errors right now.