### PR TITLE
Add check for fields not existing when writing container

### DIFF
--- a/src/datatypes/compiler-structures.js
+++ b/src/datatypes/compiler-structures.js
@@ -96,6 +96,7 @@ module.exports = {
           for (const { name } of type[1]) {
             const trueName = compiler.getField(name)
             code += `const ${trueName} = value.${name}\n`
+            code += `if (${trueName} === undefined) throw new Error("Missing bitfield field '${trueName}'")\n`
             if (name === trueName) names.push(name)
             else names.push(`${name}: ${trueName}`)
           }
@@ -104,6 +105,7 @@ module.exports = {
           trueName = compiler.getField(name)
           if (_shouldBeInlined) code += `let ${name} = value\n`
           else code += `let ${trueName} = value.${name}\n`
+          code += `if (${trueName} === undefined) throw new Error("Missing field '${trueName}'")\n`
         }
         code += 'offset = ' + compiler.callType(trueName, type) + '\n'
       }

--- a/src/datatypes/compiler-structures.js
+++ b/src/datatypes/compiler-structures.js
@@ -96,7 +96,7 @@ module.exports = {
           for (const { name } of type[1]) {
             const trueName = compiler.getField(name)
             code += `const ${trueName} = value.${name}\n`
-            code += `if (${trueName} === undefined) throw new Error("Missing bitfield field '${trueName}'")\n`
+            code += `if (${trueName} === undefined) throw new Error("Missing bitfield field '${name}'")\n`
             if (name === trueName) names.push(name)
             else names.push(`${name}: ${trueName}`)
           }
@@ -105,7 +105,7 @@ module.exports = {
           trueName = compiler.getField(name)
           if (_shouldBeInlined) code += `let ${name} = value\n`
           else code += `let ${trueName} = value.${name}\n`
-          code += `if (${trueName} === undefined) throw new Error("Missing field '${trueName}'")\n`
+          if (requiresValue(compiler, type)) code += `if (${trueName} === undefined) throw new Error("Missing field '${name}'")\n`
         }
         code += 'offset = ' + compiler.callType(trueName, type) + '\n'
       }
@@ -164,6 +164,15 @@ module.exports = {
       return compiler.wrapCode(code)
     }]
   }
+}
+
+// Builtin types that cannot encode an absent value; a type the compiler does not
+// define may accept undefined, and void, switch and option do.
+const valueTypes = new Set([...Object.keys(require('./numeric')), 'varint', 'bool', 'pstring', 'cstring', 'buffer', 'bitfield', 'mapper', 'array', 'count', 'container'])
+
+function requiresValue (compiler, type) {
+  while (typeof type === 'string' && compiler.types[type] && compiler.types[type] !== 'native') type = compiler.types[type]
+  return valueTypes.has(Array.isArray(type) ? type[0] : type)
 }
 
 function uniqueId () {

--- a/test/missingFields.js
+++ b/test/missingFields.js
@@ -1,0 +1,57 @@
+/* eslint-env mocha */
+
+const expect = require('chai').expect
+const { ProtoDefCompiler } = require('protodef').Compiler
+
+const compiler = new ProtoDefCompiler()
+compiler.addTypes({
+  Read: {
+    maybe: ['native', (buffer, offset) => ({ value: buffer[offset] || undefined, size: 1 })],
+    maybeType: ['parametrizable', (compiler) => compiler.wrapCode('return { value: buffer[offset] || undefined, size: 1 }')]
+  },
+  Write: {
+    maybe: ['native', (value, buffer, offset) => { buffer[offset] = value === undefined ? 0 : value; return offset + 1 }],
+    maybeType: ['parametrizable', (compiler) => compiler.wrapCode('buffer[offset] = value === undefined ? 0 : value\nreturn offset + 1')]
+  },
+  SizeOf: {
+    maybe: ['native', () => 1],
+    maybeType: ['parametrizable', (compiler) => compiler.wrapCode('return 1')]
+  }
+})
+compiler.addTypesToCompile({
+  maybe: 'native',
+  anonMaybe: ['maybeType', {}],
+  count: 'u8',
+  hit: ['option', 'u8'],
+  packet: ['container', [
+    { name: 'mouse', type: 'u8' },
+    { name: 'x', type: ['switch', { compareTo: 'mouse', fields: { 2: 'u8' }, default: 'void' }] },
+    { name: 'y', type: 'hit' },
+    { name: 'extra', type: ['option', 'u8'] },
+    { name: 'nbt', type: 'maybe' },
+    { name: 'anonNbt', type: 'anonMaybe' },
+    { name: 'nothing', type: 'void' }
+  ]],
+  pair: ['container', [
+    { name: 'a', type: 'u8' },
+    { name: 'b', type: 'count' },
+    { name: 'flags', anon: true, type: ['bitfield', [{ name: 'c', size: 4, signed: false }, { name: 'd', size: 4, signed: false }]] }
+  ]]
+})
+const proto = compiler.compileProtoDefSync()
+
+describe('compiled container write', () => {
+  it('rejects a missing field', () => {
+    expect(() => proto.createPacketBuffer('pair', { a: 1, c: 1, d: 1 })).to.throw("Missing field 'b'")
+  })
+  it('rejects an undefined field behind a type alias', () => {
+    expect(() => proto.createPacketBuffer('pair', { a: 1, b: undefined, c: 1, d: 1 })).to.throw("Missing field 'b'")
+  })
+  it('rejects a missing bitfield field', () => {
+    expect(() => proto.createPacketBuffer('pair', { a: 1, b: 2, c: 1 })).to.throw("Missing bitfield field 'd'")
+  })
+  it('accepts absent switch, option, void and native fields', () => {
+    expect(proto.createPacketBuffer('packet', { mouse: 0 })).to.deep.equal(Buffer.from([0, 0, 0, 0, 0]))
+    expect(proto.createPacketBuffer('packet', { mouse: 2, x: 7, y: 8, extra: 9, nbt: 5, anonNbt: 6 })).to.deep.equal(Buffer.from([2, 7, 1, 8, 1, 9, 5, 6]))
+  })
+})


### PR DESCRIPTION
There is a common problem that when the protocol gets updated some fields are silently writing garbage, so let's try to catch that.

Compiled container writes throw `Missing field 'x'` when a field is undefined and its type is one of protodef's value types: the numeric types, `varint`, `bool`, `pstring`, `cstring`, `buffer`, `bitfield`, `mapper`, `array`, `count`, `container`, or an alias of one. Bitfield members are always required.

Fields typed `void`, `switch`, `option`, or a type protodef does not define are not checked: those can encode an absent value (a switch whose default is `void`, prismarine-nbt's optional tags), and minecraft-protocol sends them undefined on purpose (`use_entity` with `mouse: 0`, a `Slot` without NBT on 1.13-1.20.4).

The interpreter is unchanged: it does not keep the JSON of a named type, so it cannot tell a switch alias from a varint alias.

minecraft-protocol's `packetTest` seeds `SpawnInfo` without `seaLevel` (1.21.2+); that varint was written as 0 before and now fails the `login`/`respawn` cases with `Missing field 'seaLevel'`.