### PR TITLE
Update commands.yml to use GITHUB_TOKEN

### DIFF
--- a/.github/workflows/commands.yml
+++ b/.github/workflows/commands.yml
@@ -16,7 +16,7 @@ jobs:
       uses: PrismarineJS/prismarine-repo-actions@master
       with:
         # NOTE: You must specify a Personal Access Token (PAT) with repo access here. While you can use the default GITHUB_TOKEN, actions taken with it will not trigger other actions, so if you have a CI workflow, commits created by this action will not trigger it.
-        token: ${{ secrets.PAT_PASSWORD }}
+        token: ${{ secrets.GITHUB_TOKEN }}
         # See `Options` section below for more info on these options
         install-command: npm install
         /fixlint.fix-command: npm run fix


### PR DESCRIPTION
Fix https://github.com/ProtoDef-io/node-protodef/issues/161 because the PAT doesn't have permission to repo

CI won't auto run with default `GITHUB_TOKEN` when a new PR is opened but it will on merge, [eg](https://github.com/extremeheat/minecraft-bedrock-server/pull/16)