### PR TITLE
Load protodef-validator only when validation is requested

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,7 @@
 const ProtoDef = require('./protodef')
-const proto = new ProtoDef()
+// No validation: this instance only supplies the default types export, and
+// validation here would load the validator for every consumer of the package.
+const proto = new ProtoDef(false)
 
 module.exports = {
   ProtoDef,

--- a/src/protodef.js
+++ b/src/protodef.js
@@ -1,6 +1,5 @@
 const { getFieldInfo, tryCatch } = require('./utils')
 const reduce = require('lodash.reduce')
-const Validator = require('protodef-validator')
 
 function isFieldInfo (type) {
   return typeof type === 'string' ||
@@ -43,7 +42,9 @@ function extendType (functions, defaultTypeArgs) {
 class ProtoDef {
   constructor (validation = true) {
     this.types = {}
-    this.validator = validation ? new Validator() : null
+    // Required here, not at the top: the validator's schema stack (ajv)
+    // must not load when validation is disabled.
+    this.validator = validation ? new (require('protodef-validator'))() : null
     this.addDefaultTypes()
   }
 


### PR DESCRIPTION
## Problem

`require('protodef')` loads `protodef-validator` and its ajv dependency tree for every consumer, even ones that never validate (e.g. node-minecraft-protocol's serializer uses `new ProtoDef(false)`). Profiling `require('mineflayer')` with a `Module._load` hook shows the validator+ajv subtree costs ~19ms warm — noticeably more with a cold file cache — out of a ~140ms warm require.

Two eager load points:
- `src/protodef.js` requires the validator at the top of the module, unconditionally.
- `src/index.js` constructs a module-scope `new ProtoDef()` (validation defaults on) just to export the default `types`, so even the lazy require would still fire for everyone.

## Change

- Move the require into the constructor's `validation ? ... : null` branch, so it loads on first validated construction.
- Build the types-export instance with validation off — the validator only validates, it never affects the constructed types.

Validation behavior when requested is unchanged: `new ProtoDef(true)` (the default) still constructs a working validator.

## Verification

- `npm test`: 497 passing, standard clean.
- After the change, `require('protodef')` no longer has `protodef-validator` in `require.cache`; `new ProtoDef(true)` still does.