### PR TITLE
Compiled mapper: throw on a value not in the mappings instead of writing it

### DIFF
--- a/src/datatypes/compiler-utils.js
+++ b/src/datatypes/compiler-utils.js
@@ -159,7 +159,9 @@ return (ctx.${type})(val, buffer, offset)
     }],
     mapper: ['parametrizable', (compiler, mapper) => {
       const mappings = JSON.stringify(swapMappings(mapper.mappings))
-      const code = 'return ' + compiler.callType(`${mappings}[value] || value`, mapper.type)
+      let code = `const mapped = ${mappings}[value]\n`
+      code += 'if (mapped === undefined) throw new Error(value + \' is not in the mappings value\')\n'
+      code += 'return ' + compiler.callType('mapped', mapper.type)
       return compiler.wrapCode(code)
     }]
   },
@@ -211,7 +213,9 @@ return (ctx.${type})(val)
     }],
     mapper: ['parametrizable', (compiler, mapper) => {
       const mappings = JSON.stringify(swapMappings(mapper.mappings))
-      const code = 'return ' + compiler.callType(`${mappings}[value] || value`, mapper.type)
+      let code = `const mapped = ${mappings}[value]\n`
+      code += 'if (mapped === undefined) throw new Error(value + \' is not in the mappings value\')\n'
+      code += 'return ' + compiler.callType('mapped', mapper.type)
       return compiler.wrapCode(code)
     }]
   }

--- a/test/misc.js
+++ b/test/misc.js
@@ -1,5 +1,27 @@
 /* eslint-env mocha */
 
+const assert = require('assert')
+const { ProtoDef } = require('../')
+const { ProtoDefCompiler } = require('../').Compiler
+
 it('example works', () => {
   require('../example')
+})
+
+describe('mapper', () => {
+  const mapper = ['mapper', { type: 'varint', mappings: { '0x00': 'zero', '0x01': 'one' } }]
+  const proto = new ProtoDef()
+  proto.addType('name', mapper)
+  const compiler = new ProtoDefCompiler()
+  compiler.addTypesToCompile({ name: mapper })
+  const compiled = compiler.compileProtoDefSync()
+
+  for (const [label, p] of [['interpreted', proto], ['compiled', compiled]]) {
+    it(`writes a value mapped to 0 (${label})`, () => {
+      assert.deepStrictEqual(p.createPacketBuffer('name', 'zero'), Buffer.from([0]))
+    })
+    it(`throws on a value not in the mappings instead of writing it (${label})`, () => {
+      assert.throws(() => p.createPacketBuffer('name', 'nope'), /nope is not in the mappings value/)
+    })
+  }
 })


### PR DESCRIPTION
The compiled write/sizeOf `mapper` falls through to the raw value when it isn't in the mappings (`mappings[value] || value`), so an unmapped name reaches the underlying numeric type and serializes as `NaN` → `0`. The interpreted mapper throws `<value> is not in the mappings value` on the same input; this makes the compiled one match.

Why it matters: in node-minecraft-protocol, writing a packet name that doesn't exist in the current protocol state (e.g. mineflayer's physics loop sending `position` while a Velocity server transfer has the client in the configuration state) serialized to a single `0x00` byte with no body. In the configuration state that's a real packet id (`client_information`), so the proxy fails to decode it and kicks with "An internal error occurred in your connection." With this change the write raises a serialization error instead of putting corrupt bytes on the wire.

The `|| value` fallback also meant a value legitimately mapped to `0` only worked by accident: `0` is falsy, so the *name* was passed to the numeric type and happened to serialize as `NaN` → `0`. Covered by the new test.

Read is left as is (it still returns the raw id for an unknown value), since consumers rely on receiving unknown packets rather than a parse error.

Heads-up for consumers: anything that was serializing a mapper from `undefined`/an unmapped value and silently getting `0` now throws. Found two in the login path and fixed them ahead of this:
- PrismarineJS/node-minecraft-protocol#1519 (`particleStatus` in the configuration-phase `settings`)
- PrismarineJS/mineflayer#4045 (same field in the play-phase `settings`)
