### PR TITLE
FullPacketParser: emit partialReadError with the chunk it could not read

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -66,6 +66,20 @@ Create a parser of `mainType` defined in `proto`. This is a Transform stream.
 
 Returns a parsed packet of `buffer`.
 
+## FullPacketParser(proto,mainType,noErrorLogging)
+
+Create a parser of `mainType` defined in `proto` that reads one whole packet per chunk. This is a Transform stream.
+
+A chunk the definitions cannot read is dropped and the stream continues. Its stack is logged unless `noErrorLogging` is set.
+
+### FullPacketParser.parsePacketBuffer(buffer)
+
+Returns a parsed packet of `buffer`.
+
+### Event: 'partialReadError' (error)
+
+Emitted for each dropped chunk, before it is logged. `error.buffer` is the chunk.
+
 ## types
 
 An object mapping the default type names to the corresponding `[read,write,sizeOf]` functions.

--- a/index.d.ts
+++ b/index.d.ts
@@ -109,6 +109,8 @@ declare class CompiledProtoDef extends AbstractProtoDefInterface {
 
 declare class ProtodefPartialError extends Error {
   partialReadError: true
+  // The chunk a FullPacketParser could not read; set when it emits 'partialReadError'.
+  buffer?: Buffer
   constructor(message?: string)
 }
 
@@ -134,6 +136,8 @@ declare module 'protodef' {
     noErrorLogging: boolean
     constructor(proto: ProtoDef, mainType: string, noErrorLogging = false)
     parsePacketBuffer(packet: any): Buffer
+    on(event: 'partialReadError', listener: (error: ProtodefPartialError) => void): this
+    on(event: string | symbol, listener: (...args: any[]) => void): this
   }
   export const Compiler: {
     ReadCompiler: typeof ProtodefReadCompiler

--- a/src/serializer.js
+++ b/src/serializer.js
@@ -78,6 +78,8 @@ class FullPacketParser extends Transform {
       }
     } catch (e) {
       if (e.partialReadError) {
+        e.buffer = chunk
+        this.emit('partialReadError', e)
         if (!this.noErrorLogging) {
           console.log(e.stack)
         }

--- a/test/misc.js
+++ b/test/misc.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 
 const assert = require('assert')
-const { ProtoDef } = require('../')
+const { ProtoDef, FullPacketParser } = require('../')
 const { ProtoDefCompiler } = require('../').Compiler
 
 it('example works', () => {
@@ -22,6 +22,32 @@ describe('mapper', () => {
     })
     it(`throws on a value not in the mappings instead of writing it (${label})`, () => {
       assert.throws(() => p.createPacketBuffer('name', 'nope'), /nope is not in the mappings value/)
+    })
+  }
+})
+
+describe('FullPacketParser', () => {
+  const packet = ['container', [{ name: 'a', type: 'i32' }]]
+  const proto = new ProtoDef()
+  proto.addType('packet', packet)
+  const compiler = new ProtoDefCompiler()
+  compiler.addTypesToCompile({ packet })
+  const compiled = compiler.compileProtoDefSync()
+
+  for (const [label, p] of [['interpreted', proto], ['compiled', compiled]]) {
+    it(`emits partialReadError with the chunk it could not read, and keeps parsing (${label})`, async () => {
+      const parser = new FullPacketParser(p, 'packet', true)
+      const errors = []
+      const packets = []
+      parser.on('partialReadError', e => errors.push(e))
+      parser.on('data', d => packets.push(d.data))
+      parser.write(Buffer.from([0, 0]))
+      parser.write(Buffer.from([0, 0, 0, 7]))
+      await new Promise(resolve => parser.end(resolve))
+      assert.strictEqual(errors.length, 1)
+      assert.strictEqual(errors[0].partialReadError, true)
+      assert.deepStrictEqual(errors[0].buffer, Buffer.from([0, 0]))
+      assert.deepStrictEqual(packets, [{ a: 7 }])
     })
   }
 })


### PR DESCRIPTION
`FullPacketParser._transform` drops a chunk it cannot read and moves on, which is the right behaviour for a stream of whole packets. But it discards the chunk on the way: the only trace is `console.log(e.stack)`, and even that goes away under `noErrorLogging`. A consumer cannot find out which bytes failed to parse.

That matters when a server's registry disagrees with the client's definitions. A 1.21.3 server sending particle id 47 (`item_slime`, no payload) to a 1.21.4 client, whose definitions read 47 as `trail` (a `vec3f64` and more), throws `PartialReadError` on every particle packet. One bot logged 14,814 stacks, none of them carrying the packet.

This attaches the chunk to the error as `error.buffer` and emits it as `'partialReadError'` before the existing log, so a consumer can record the bytes, diff them against the schema, or count them. The event is not `'error'`: emitting that on a Transform ends the stream, which is exactly what the drop-and-continue path exists to avoid.

Nothing else changes. The log line and the drop are as before, and `noErrorLogging` still controls only the log. `Parser` is untouched: a partial read there means the rest of the packet has not arrived yet, not that the bytes are wrong.

The plain `Parser` already sets `e.buffer` on the errors it forwards, so the field name follows it.

Typed in `index.d.ts` and documented in `doc/api.md`, which had no `FullPacketParser` section. Test covers the interpreted and compiled parsers: the event fires once with the chunk, and the next packet still parses.
