### PR TITLE
Throttle repeated packet-parse error logs in FullPacketParser

### DIFF
--- a/src/serializer.js
+++ b/src/serializer.js
@@ -1,5 +1,15 @@
 const Transform = require('readable-stream').Transform
 
+// A malformed stream can make the same packet fail to parse for every frame it sends -- thousands
+// of identical stacks a minute. Log the first occurrence of each in full, then only at 1, 2, 4, 8,
+// ... so a persistent fault stays O(log n) instead of unbounded. Keyed per parser instance.
+function logThrottled (counts, key, full) {
+  const n = (counts.get(key) || 0) + 1
+  counts.set(key, n)
+  if (n === 1) console.log(full)
+  else if ((n & (n - 1)) === 0) console.log(`${key} (repeated ${n} times)`)
+}
+
 class Serializer extends Transform {
   constructor (proto, mainType) {
     super({ writableObjectMode: true })
@@ -62,6 +72,7 @@ class FullPacketParser extends Transform {
     this.proto = proto
     this.mainType = mainType
     this.noErrorLogging = noErrorLogging
+    this.errorCounts = new Map()
   }
 
   parsePacketBuffer (buffer) {
@@ -73,13 +84,14 @@ class FullPacketParser extends Transform {
     try {
       packet = this.parsePacketBuffer(chunk)
       if (packet.metadata.size !== chunk.length && !this.noErrorLogging) {
-        console.log('Chunk size is ' + chunk.length + ' but only ' + packet.metadata.size + ' was read ; partial packet : ' +
+        logThrottled(this.errorCounts, 'chunk size mismatch',
+          'Chunk size is ' + chunk.length + ' but only ' + packet.metadata.size + ' was read ; partial packet : ' +
           JSON.stringify(packet.data) + '; buffer :' + chunk.toString('hex'))
       }
     } catch (e) {
       if (e.partialReadError) {
         if (!this.noErrorLogging) {
-          console.log(e.stack)
+          logThrottled(this.errorCounts, e.stack.split('\n')[0], e.stack)
         }
         return cb()
       } else {


### PR DESCRIPTION
### Problem

When a stream is malformed or version-mismatched, the same packet can fail to parse on every frame the server sends. `FullPacketParser._transform` logged the full stack on each `PartialReadError`, so one persistent fault produced thousands of identical stacks a minute and drowned every other log line. A real session was seen emitting ~15,000 identical `Read error for undefined : undefined` stacks — tens of megabytes — over ~45 minutes.

### Change

A small per-instance throttle: each distinct error (keyed on the top line of its stack) is logged in full on its **first** occurrence, then again only at the 1st, 2nd, 4th, 8th, … occurrence with a repeat count. A persistent fault costs O(log n) lines instead of n, while the first full stack — the part you actually diagnose from — is always kept, and distinct faults are still each reported. The same throttle is applied to the chunk-size-mismatch log two lines up, which is the same failure family.

`noErrorLogging` still suppresses everything, unchanged.

### Testing

- 1,000 identical partial-read errors → 10 log lines (n = 1, 2, 4, … 512); two interleaved signatures × 4 each → 6 lines (each hits 1, 2, 4).
- `npm test` — all 501 existing tests pass; parser semantics unchanged.
