### PR TITLE
Serializer: name the packet in write errors from a compiled protocol

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -56,7 +56,8 @@ Create a serializer of `mainType` defined in `proto`. This is a Transform stream
 
 ### Serializer.createPacketBuffer(packet)
 
-Returns a buffer of the `packet`.
+Returns a buffer of the `packet`. If serialization fails and `packet.name` is set, the error message is prefixed with
+`in packet <name>: ` unless the error's field path already contains that name.
 
 ## Parser(proto,mainType)
 

--- a/src/serializer.js
+++ b/src/serializer.js
@@ -9,7 +9,16 @@ class Serializer extends Transform {
   }
 
   createPacketBuffer (packet) {
-    return this.proto.createPacketBuffer(this.mainType, packet)
+    try {
+      return this.proto.createPacketBuffer(this.mainType, packet)
+    } catch (e) {
+      // A compiled protocol reports no field path, so the packet name is the only way to say which packet failed
+      const name = packet?.name
+      if (name != null && !String(e.field ?? '').split('.').includes(String(name))) {
+        e.message = `in packet ${name}: ${e.message}`
+      }
+      throw e
+    }
   }
 
   _transform (chunk, enc, cb) {

--- a/test/misc.js
+++ b/test/misc.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 
 const assert = require('assert')
-const { ProtoDef } = require('../')
+const { ProtoDef, Serializer } = require('../')
 const { ProtoDefCompiler } = require('../').Compiler
 
 it('example works', () => {
@@ -24,4 +24,33 @@ describe('mapper', () => {
       assert.throws(() => p.createPacketBuffer('name', 'nope'), /nope is not in the mappings value/)
     })
   }
+})
+
+describe('Serializer', () => {
+  const types = {
+    packet_position: ['container', [{ name: 'x', type: 'f64' }, { name: 'face', type: ['mapper', { type: 'varint', mappings: { 0: 'down' } }] }]],
+    packet: ['container', [
+      { name: 'name', type: ['mapper', { type: 'varint', mappings: { 0: 'position' } }] },
+      { name: 'params', type: ['switch', { compareTo: 'name', fields: { position: 'packet_position' } }] }
+    ]]
+  }
+  const proto = new ProtoDef()
+  proto.addTypes(types)
+  const compiler = new ProtoDefCompiler()
+  compiler.addTypesToCompile(types)
+  const compiled = compiler.compileProtoDefSync()
+  const bad = { name: 'position', params: { x: 1, face: 'up' } }
+
+  it('names the packet when the error has no field path (compiled)', () => {
+    assert.throws(() => new Serializer(compiled, 'packet').createPacketBuffer(bad),
+      { message: 'in packet position: SizeOf error for undefined : up is not in the mappings value' })
+  })
+  it('does not repeat a packet name already in the field path (interpreted)', () => {
+    assert.throws(() => new Serializer(proto, 'packet').createPacketBuffer(bad),
+      { message: 'SizeOf error for params.position.face : up is not in the mappings value' })
+  })
+  it('leaves errors alone when the value has no name', () => {
+    assert.throws(() => new Serializer(compiled, 'packet_position').createPacketBuffer(bad.params),
+      { message: 'SizeOf error for undefined : up is not in the mappings value' })
+  })
 })


### PR DESCRIPTION
### Problem

Every packet write goes through `Serializer.createPacketBuffer`, but a compiled protocol never sets `e.field`, so the errors coming out say nothing about which packet failed:

```
Error: Write error for undefined : Missing field 'x'
Error: SizeOf error for undefined : 0 is not in the mappings value
```

The interpreter names it through the switch's field path (`params.position.face`); the compiler reports no path at all. The error is thrown inside `_transform` and surfaces asynchronously on the stream, so a caller cannot attribute it after the fact either.

### Change

`Serializer.createPacketBuffer` prefixes the message with `in packet <name>: ` when the value has a `name` and the error's field path does not already contain it:

```
in packet position: SizeOf error for undefined : up is not in the mappings value
```

Interpreted errors and values without a `name` are untouched.

### Testing

- New tests in `test/misc.js`: compiled gets the prefix, interpreted keeps its field path with no duplicate, a value with no `name` is left alone.
- `npm test`: lint clean, 504 passing.